### PR TITLE
Repo name in CONTRIBUTING.md and link from README to spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,34 +25,26 @@ describe.
 
 ## Development Environment Setup
 
-
-### Prerequisites
-
-   ``` sh
-   # show how to install the tools needed to work with the code here
-   ```
-
-
 ### GitHub Repository Clone
 
 To prepare your dedicated GitHub repository:
 
-1. Fork in GitHub https://github.com/atsign-foundation/REPO
-2. Clone *your forked repository* (e.g., `git clone git@github.com:yourname/REPO`)
+1. Fork in GitHub https://github.com/atsign-foundation/at_protocol
+2. Clone *your forked repository* (e.g., `git clone git@github.com:yourname/at_protocol`)
 3. Set your remotes as follows:
 
    ```sh
-   cd REPO
-   git remote add upstream git@github.com:atsign-foundation/REPO.git
+   cd at_protocol
+   git remote add upstream git@github.com:atsign-foundation/at_protocol.git
    git remote set-url upstream --push DISABLED
    ```
 
    Running `git remote -v` should give something similar to:
 
    ```text
-   origin  git@github.com:yourname/REPO.git (fetch)
-   origin  git@github.com:yourname/REPO.git (push)
-   upstream        git@github.com:atsign-foundation/REPO.git (fetch)
+   origin  git@github.com:yourname/at_protocol.git (fetch)
+   origin  git@github.com:yourname/at_protocol.git (push)
+   upstream        git@github.com:atsign-foundation/at_protocol.git (fetch)
    upstream        DISABLED (push)
    ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # The At Protocol Specification
 
-This repository is home to the open source specification for The @protocol as well as supporting documentation.
+This repository is home to the [open source specification for The @protocol](specification/at_protocol_specification.md) as well as supporting documentation.
 
 ## This repo is for anyone interested in:
 


### PR DESCRIPTION
**- What I did**

Replaced 'REPO' in CONTRIBUTING.md with at_protocol
Added link from README.md to spec

**- How to verify it**

Eyeball cpswan/at_protocol

**- Description for the changelog**

Repo name in CONTRIBUTING.md and link from README to spec