### PR TITLE
docs: missing scan verb + notify, monitor verbs heading 3

### DIFF
--- a/specification/at_protocol_specification.md
+++ b/specification/at_protocol_specification.md
@@ -515,6 +515,7 @@ NA
 The scan verb is used to see the keys in an atSign's secondary server. 
 
 Following regex represents the syntax of the `scan` verb:
+
 ```r'^scan$|scan(:showhidden:(?<showhidden>true|false))?(:(?<forAtSign>@[^:@\s]+))?(:page:(?<page>\d+))?( (?<regex>\S+))?$'```
 
 **Response:**

--- a/specification/at_protocol_specification.md
+++ b/specification/at_protocol_specification.md
@@ -893,7 +893,7 @@ If the user is the owner, returns a list of received notifications. If a user is
 
 ```data:[{"id":"0e5e9e89-c9cb-423b-8972-8c5487215990","from":"@alice","to":"@bob","key":"@bob:phone@alice","value":12345,"operation":"update","epochMillis":1603714122636}]```
 
-The `monitor` Verb
+### The `monitor` Verb
 
 **Synopsis:**
 

--- a/specification/at_protocol_specification.md
+++ b/specification/at_protocol_specification.md
@@ -856,7 +856,7 @@ data:[{"atKey":"@bob:phone@alice","operation":"+","opTime":"2020-10-26 11:57:43.
 {"atKey":"@bob:shared_key@alice","operation":"-","opTime":"2020-10-26 09:44:54.382219Z","commitId":1}]
 ```
 
-The `notify` verb
+### The `notify` verb
 
 The `notify` verb enables us to notify the atsign user of some data event.
 

--- a/specification/at_protocol_specification.md
+++ b/specification/at_protocol_specification.md
@@ -508,6 +508,21 @@ The `pol` verb follows the `from` verb. 'pol' indicates another secondary that t
 
 NA
 
+### The `scan` verb
+
+**Synopsis:**
+
+The scan verb is used to see the keys in an atSign's secondary server. 
+
+Following regex represents the syntax of the `scan` verb:
+```r'^scan$|scan(:showhidden:(?<showhidden>true|false))?(:(?<forAtSign>@[^:@\s]+))?(:page:(?<page>\d+))?( (?<regex>\S+))?$'```
+
+**Response:**
+
+The Secondary Server should return the keys within the secondary server if the scan verb executed succesfully. The Secondary Server will respond accordingly to whether the atSign is authenticated or not.
+
+```data:[<keys>]```
+
 ### The `update` verb
 
 **Synopsis:**


### PR DESCRIPTION
**- What I did**
- Added `###` to **the notify verb** and **the monitor verb** for it to show in the ToC
- Added **the scan verb** because it was missing

![image](https://user-images.githubusercontent.com/79019866/179619956-f689ebd9-83fe-45b2-b537-b294b13836fe.png)

**- How to verify it**
Before:
![image](https://user-images.githubusercontent.com/79019866/179619417-d3ecc5ba-59bf-47ed-a95c-87692be015d7.png)
After:
![image](https://user-images.githubusercontent.com/79019866/179619438-4694ec22-8f6f-49c9-907a-76cfa2740fe7.png)