### PR TITLE
docs: Provide an example of notify

### DIFF
--- a/specification/at_protocol_specification.md
+++ b/specification/at_protocol_specification.md
@@ -17,13 +17,13 @@
   <tr>
    <td><strong>Revision</strong>
    </td>
-   <td>v0.1.2 (draft)
+   <td>v0.1.3 (draft)
    </td>
   </tr>
   <tr>
    <td><strong>Date</strong>
    </td>
-   <td>Mar, 3, 2023
+   <td>Mar, 14, 2023
    </td>
   </tr>
 </table>

--- a/specification/at_protocol_specification.md
+++ b/specification/at_protocol_specification.md
@@ -879,14 +879,23 @@ The `notify` verb enables us to notify the atSign user of some data event.
 The Following is the regex for the `notify` verb
 
 
-```notify:((?<operation>update|delete):)?(ttl:(?<ttl>\d+):)?(ttb:(?<ttb>\d+):)?(ttr:(?<ttr>(-)?\d+):)?(ccd:(?<ccd>true|false):)?(@(?<forAtSign>[^@:\s]-)):(?<atKey>[^:]((?!:{2})[^@])+)@(?<atSign>[^@:\s]+)(:(?<value>.+))?```
+```
+notify:((?<operation>update|delete):)?(ttl:(?<ttl>\d+):)?(ttb:(?<ttb>\d+):)?(ttr:(?<ttr>(-)?\d+):)?(ccd:(?<ccd>true|false):)?(@(?<forAtSign>[^@:\s]-)):(?<atKey>[^:]((?!:{2})[^@])+)@(?<atSign>[^@:\s]+)(:(?<value>.+))?
+```
+
+**Example:**
+
+```
+notify:update:ttr:-1:@{RECIPIENT}:{KEY}.{NAMESPACE}@{SENDER}:{BASE64ENCODED_CYPHERTEXT}
+```
 
 **Response:**
 
-When a key is notified successfully, returns 
+When a key is notified successfully, returns `data:{ID}` e.g.
 
-
-```data:success```
+```
+data:fccf2ddc-9316-4302-a11b-3dd214857431
+```
 
 **Description:**
 


### PR DESCRIPTION
closes https://github.com/atsign-foundation/at_protocol/issues/50

The current regex doesn't provide a clear example of minimal viable notify.

We also incorrectly state that the expected response is `data:success` when in fact an ID is returned.

**- What I did**

* Added an example
* Corrected expected response
* Provided an example response

**- How I did it**

Taken from 'minimal viable notify' supplied by @gkc and tested with Infrafon and at_pico_w

**- How to verify it**

Rich preview will show changes

**- Description for the changelog**

docs: Provide an example of notify