### PR TITLE
fix: key pair encryption with APKAM public key

### DIFF
--- a/decisions/2023-01-pkam-per-app-and-device.md
+++ b/decisions/2023-01-pkam-per-app-and-device.md
@@ -138,7 +138,7 @@ This proposal is based upon, and expands upon, [this summary proposal](https://d
     - Retrieves everything from the `__private_keys.__global` namespace
     - Retrieves everything from `__private_keys.$namespace` for each $namespace to
       which this app has access
-  - (Recall that these are encrypted with FirstApp's APKAM private key)
+  - (Recall that these are encrypted with FirstApp's APKAM public key)
 - Retrieve all self encryption keys
   - `keys:get:self`
     - Retrieves everything from the `__self_keys.__global` namespace


### PR DESCRIPTION
**- What I did**
- fixed an error in documentation
**- How I did it**
- keypairs are encrypted with APKAM public key. In the documentation, APKAM private key was mentioned
**- How to verify it**
n/a