### PR TITLE
docs: Add OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://github.com/atsign-foundation/at_protocol/blob/trunk/LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_protocol/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_protocol)
+NA - Documentation repo, though implementations such as at_client_sdk do have tests
 
 # The atProtocol Specification
 


### PR DESCRIPTION
Improving our OpenSSF Scorecard requires the badge to be found.

**- What I did**

Added OpenSSF Best practice badge to README

**- How I did it**

Pasted in link provided at https://www.bestpractices.dev/en/projects/8118

**- How to verify it**

Badge is visible in rich diff preview

**- Description for the changelog**

docs: Add OpenSSF Best practice badge to README