### PR TITLE
docs: Lint README and remove spurious line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,39 @@
-<a href="https://atsign.com#gh-light-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only" alt="The Atsign Foundation"></a><a href="https://atsign.com#gh-dark-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2023/08/atsign-logo-horizontal-reverse2022-Color.svg#gh-dark-mode-only" alt="The Atsign Foundation"></a>
+<h1><a href="https://atsign.com#gh-light-mode-only">
+<img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only"
+alt="The Atsign Foundation"></a><a href="https://atsign.com#gh-dark-mode-only">
+<img width=250px src="https://atsign.com/wp-content/uploads/2023/08/atsign-logo-horizontal-reverse2022-Color.svg#gh-dark-mode-only"
+alt="The Atsign Foundation"></a></h1>
 
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://github.com/atsign-foundation/at_protocol/blob/trunk/LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_protocol/badge)](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_protocol)
-NA - Documentation repo, though implementations such as at_client_sdk do have tests
 
 # The atProtocol Specification
 
-This repository is home to the [open source specification for The atProtocol](specification/at_protocol_specification.md) as well as supporting documentation.
+This repository is home to the
+[open source specification for The atProtocol](specification/at_protocol_specification.md)
+as well as supporting documentation.
 
-## This repo is for anyone interested in:
+## This repo is for anyone interested in
 
 1. Understanding what The atProtocol is and how it works.
-2. Contributing to the specification with suggestions, edits or proposed changes.
-3. Implementing another reference implementation that us interoperatable with others.
+2. Contributing to the specification with suggestions, edits or proposed
+changes.
+3. Implementing another reference implementation that us interoperatable with
+others.
 
-The intent of the specifation is to define the actors, roles, responsibilities required to implement a working system that is atProtocol compliant.
+The intent of the specifation is to define the actors, roles, responsibilities
+required to implement a working system that is atProtocol compliant.
 
-The specification itself is a simple markdown document that is easiy to view and edit.
+The specification itself is a simple markdown document that is easiy to view
+and edit.
 
 ### Contributing
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidance on how to submit changes and make pull requests.
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidance on how to
+submit changes and make pull requests.
 
 ## Maintainers
+
 This document was created and is maintained by:
 - [Colin Constable](https://github.com/cconstab)
 - [Murali Dharan](https://github.com/murali-shris)


### PR DESCRIPTION
Text meant for OpenSSF questionnaire was typed into the wrong window and found its way into README

> NA - Documentation repo, though implementations such as at_client_sdk do have tests

**- What I did**

* Removed spurious line
* Markdown lints

**- How I did it**

pymarkdownlnt

**- How to verify it**

Visible in rich diff

**- Description for the changelog**

docs: Lint README and remove spurious line