### PR TITLE
docs: decision on minimum version of C SDK (ANSI C or C99)

### DIFF
--- a/decisions/2024-02-c99-minimum-version.md
+++ b/decisions/2024-02-c99-minimum-version.md
@@ -50,4 +50,4 @@ We are leaning towards C99 because:
 
 ### Expected Consequences <!-- optional -->
 
-- If a customer is programming in C89/90 strictly, the C SDK (in C99) may not be compatible with their code.
+* If a customer is programming in C89/90 strictly, the C SDK (in C99) may not be compatible with their code.

--- a/decisions/2024-02-c99-minimum-version.md
+++ b/decisions/2024-02-c99-minimum-version.md
@@ -5,15 +5,23 @@ https://github.com/GoogleCloudPlatform/emblem/tree/main/docs/decisions -->
 
 * **Status:** Approved
 * **Last Updated:** 2024-02-14
-* **Objective:** Objective of this document is to analyze C89/C90 and C99, and decide on a minimum version of C to support in the C SDK. Approval of this document will mean that C99 is the approved minimum version of C to support in the C SDK.
+* **Objective:** Objective of this document is to analyze C89/C90 and C99,
+and decide on a minimum version of C to support in the C SDK. Approval of
+this document will mean that C99 is the approved minimum version of C to
+support in the [at_c C SDK](https://github.com/atsign-foundation/at_c).
 
 ## Context & Problem Statement
 
-We have not made a concrete decision on which version of C to support in the C SDK. We need to make a decision on which version of C to support in the C SDK.
+We have not made a concrete decision on which version of C to support in the
+C SDK. We need to make a decision on which version of C to support in the C
+SDK.
 
 ## Goals
 
-Goal of this document is to decide on a minimum version of C to support in the C SDK. Approval of this document will mean that C99 is the approved minimum version of C to support in the C SDK. This document analyzes the impacts of choosing C99 as the minimum version of C to support in the C SDK.
+Goal of this document is to decide on a minimum version of C to support in
+the C SDK. Approval of this document will mean that C99 is the approved
+minimum version of C to support in the C SDK. This document analyzes the
+impacts of choosing C99 as the minimum version of C to support in the C SDK.
 
 ### Non-goals
 
@@ -21,11 +29,17 @@ N/A
 
 ## Other considerations <!-- optional -->
 
-C99 supports backwards compatibility with C89/90 (kind of). [source](https://en.wikipedia.org/wiki/C99).
+C99 supports backwards compatibility with C89/90 (kind of).
+[source](https://en.wikipedia.org/wiki/C99).
 
 From the source:
 
-> In particular, a declaration that lacks a type specifier no longer has int implicitly assumed. The C standards committee decided that it was of more value for compilers to diagnose inadvertent omission of the type specifier than to silently process legacy code that relied on implicit int. In practice, compilers are likely to display a warning, then assume int and continue translating the program.
+> In particular, a declaration that lacks a type specifier no longer has
+int implicitly assumed. The C standards committee decided that it was of
+more value for compilers to diagnose inadvertent omission of the type
+specifier than to silently process legacy code that relied on implicit int.
+In practice, compilers are likely to display a warning, then assume int and
+continue translating the program.
 
 ## Considered Options <!-- optional -->
 
@@ -39,15 +53,21 @@ Limit ourselves to ANSI C (C89/90) and avoid using C99 features.
 
 ## Proposal Summary
 
-After discussions found [here](https://github.com/atsign-foundation/at_c/issues/105), we are leaning to making C99 the minimum version of the C SDK.
+After discussions found
+[here](https://github.com/atsign-foundation/at_c/issues/105),
+we are leaning to making C99 the minimum version of the C SDK.
 
 ## Proposal in Detail
 
 We are leaning towards C99 because:
 
-1. Faster time to market (we can use C99 features such as bool from stdbool.h, sized ints from stdint.h), and inline functions.
-2. C99 supports backwards compatibility with C89/90 (kind of). [source](https://en.wikipedia.org/wiki/C99). See the ["Other considerations"](#other-considerations) section for more details.
+1. Faster time to market (we can use C99 features such as bool from stdbool.h,
+sized ints from stdint.h), and inline functions.
+2. C99 supports backwards compatibility with C89/90 (kind of).
+[source](https://en.wikipedia.org/wiki/C99). See the
+["Other considerations"](#other-considerations) section for more details.
 
 ### Expected Consequences <!-- optional -->
 
-* If a customer is programming in C89/90 strictly, the C SDK (in C99) may not be compatible with their code.
+* If a customer is programming in C89/90 strictly, the C SDK (in C99) may
+not be compatible with their code.

--- a/decisions/2024-02-c99-minimum-version.md
+++ b/decisions/2024-02-c99-minimum-version.md
@@ -5,16 +5,16 @@ https://github.com/GoogleCloudPlatform/emblem/tree/main/docs/decisions -->
 
 * **Status:** Draft
 * **Last Updated:** 2024-02-14
-* **Objective:** Decide on a minimum version of the C SDK to support. 
+* **Objective:** Decide on a minimum version of the C SDK to support; C89/90 or C99.
 
 ## Context & Problem Statement
 We have not made a concrete decision on which version of C to support in the C SDK. We need to make a decision on which version of C to support in the C SDK.
 
 ## Goals
-1. Decide on a minimum version of C to support in the C SDK
+Goal of this document is to decide on a minimum version of C to support in the C SDK
 
 ### Non-goals
-- Support for older versions of C such as C89/90
+N/A 
 
 ## Other considerations <!-- optional -->
 C99 supports backwards compatibility with C89/90 (kind of). [source](https://en.wikipedia.org/wiki/C99).
@@ -23,9 +23,7 @@ From the source:
 
 > In particular, a declaration that lacks a type specifier no longer has int implicitly assumed. The C standards committee decided that it was of more value for compilers to diagnose inadvertent omission of the type specifier than to silently process legacy code that relied on implicit int. In practice, compilers are likely to display a warning, then assume int and continue translating the program.
 
-
-<!-- ## Considered Options optional -->
-
+## Considered Options <!-- optional -->
 
 * ### Option 1
 Make C99 the minimum version of the C SDK and freely utilize C99 features.
@@ -40,7 +38,7 @@ After discussions found [here](https://github.com/atsign-foundation/at_c/issues/
 We are leaning towards C99 because:
 
 1. Faster time to market (we can use C99 features such as bool from stdbool.h, sized ints from stdint.h), and inline functions.
-2. C99 supports backwards compatibility with C89/90 (kind of). [source](https://en.wikipedia.org/wiki/C99)
+2. C99 supports backwards compatibility with C89/90 (kind of). [source](https://en.wikipedia.org/wiki/C99). See the ["Other considerations"](#other-considerations) section for more details.
 
 ### Expected Consequences <!-- optional -->
 - If a customer is programming in C89/90 strictly, the C SDK (in C99) may not be compatible with their code.

--- a/decisions/2024-02-c99-minimum-version.md
+++ b/decisions/2024-02-c99-minimum-version.md
@@ -8,15 +8,19 @@ https://github.com/GoogleCloudPlatform/emblem/tree/main/docs/decisions -->
 * **Objective:** Decide on a minimum version of the C SDK to support; C89/90 or C99.
 
 ## Context & Problem Statement
+
 We have not made a concrete decision on which version of C to support in the C SDK. We need to make a decision on which version of C to support in the C SDK.
 
 ## Goals
+
 Goal of this document is to decide on a minimum version of C to support in the C SDK
 
 ### Non-goals
-N/A 
+
+N/A
 
 ## Other considerations <!-- optional -->
+
 C99 supports backwards compatibility with C89/90 (kind of). [source](https://en.wikipedia.org/wiki/C99).
 
 From the source:
@@ -26,19 +30,24 @@ From the source:
 ## Considered Options <!-- optional -->
 
 * ### Option 1
+
 Make C99 the minimum version of the C SDK and freely utilize C99 features.
 
 * ### Option 2
+
 Limit ourselves to ANSI C (C89/90) and avoid using C99 features.
 
 ## Proposal Summary
+
 After discussions found [here](https://github.com/atsign-foundation/at_c/issues/105), we are leaning to making C99 the minimum version of the C SDK.
 
 ## Proposal in Detail
+
 We are leaning towards C99 because:
 
 1. Faster time to market (we can use C99 features such as bool from stdbool.h, sized ints from stdint.h), and inline functions.
 2. C99 supports backwards compatibility with C89/90 (kind of). [source](https://en.wikipedia.org/wiki/C99). See the ["Other considerations"](#other-considerations) section for more details.
 
 ### Expected Consequences <!-- optional -->
+
 - If a customer is programming in C89/90 strictly, the C SDK (in C99) may not be compatible with their code.

--- a/decisions/2024-02-c99-minimum-version.md
+++ b/decisions/2024-02-c99-minimum-version.md
@@ -3,7 +3,7 @@
 <!-- This template is inspired by
 https://github.com/GoogleCloudPlatform/emblem/tree/main/docs/decisions -->
 
-* **Status:** Draft
+* **Status:** Approved
 * **Last Updated:** 2024-02-14
 * **Objective:** Decide on a minimum version of the C SDK to support; C89/90 or C99.
 

--- a/decisions/2024-02-c99-minimum-version.md
+++ b/decisions/2024-02-c99-minimum-version.md
@@ -1,0 +1,46 @@
+# C99 Minimum Version
+
+<!-- This template is inspired by
+https://github.com/GoogleCloudPlatform/emblem/tree/main/docs/decisions -->
+
+* **Status:** Draft
+* **Last Updated:** 2024-02-14
+* **Objective:** Decide on a minimum version of the C SDK to support. 
+
+## Context & Problem Statement
+We have not made a concrete decision on which version of C to support in the C SDK. We need to make a decision on which version of C to support in the C SDK.
+
+## Goals
+1. Decide on a minimum version of C to support in the C SDK
+
+### Non-goals
+- Support for older versions of C such as C89/90
+
+## Other considerations <!-- optional -->
+C99 supports backwards compatibility with C89/90 (kind of). [source](https://en.wikipedia.org/wiki/C99).
+
+From the source:
+
+> In particular, a declaration that lacks a type specifier no longer has int implicitly assumed. The C standards committee decided that it was of more value for compilers to diagnose inadvertent omission of the type specifier than to silently process legacy code that relied on implicit int. In practice, compilers are likely to display a warning, then assume int and continue translating the program.
+
+
+<!-- ## Considered Options optional -->
+
+
+* ### Option 1
+Make C99 the minimum version of the C SDK and freely utilize C99 features.
+
+* ### Option 2
+Limit ourselves to ANSI C (C89/90) and avoid using C99 features.
+
+## Proposal Summary
+After discussions found [here](https://github.com/atsign-foundation/at_c/issues/105), we are leaning to making C99 the minimum version of the C SDK.
+
+## Proposal in Detail
+We are leaning towards C99 because:
+
+1. Faster time to market (we can use C99 features such as bool from stdbool.h, sized ints from stdint.h), and inline functions.
+2. C99 supports backwards compatibility with C89/90 (kind of). [source](https://en.wikipedia.org/wiki/C99)
+
+### Expected Consequences <!-- optional -->
+- If a customer is programming in C89/90 strictly, the C SDK (in C99) may not be compatible with their code.

--- a/decisions/2024-02-c99-minimum-version.md
+++ b/decisions/2024-02-c99-minimum-version.md
@@ -5,7 +5,7 @@ https://github.com/GoogleCloudPlatform/emblem/tree/main/docs/decisions -->
 
 * **Status:** Approved
 * **Last Updated:** 2024-02-14
-* **Objective:** Decide on a minimum version of the C SDK to support; C89/90 or C99.
+* **Objective:** Objective of this document is to analyze C89/C90 and C99, and decide on a minimum version of C to support in the C SDK. Approval of this document will mean that C99 is the approved minimum version of C to support in the C SDK.
 
 ## Context & Problem Statement
 
@@ -13,7 +13,7 @@ We have not made a concrete decision on which version of C to support in the C S
 
 ## Goals
 
-Goal of this document is to decide on a minimum version of C to support in the C SDK
+Goal of this document is to decide on a minimum version of C to support in the C SDK. Approval of this document will mean that C99 is the approved minimum version of C to support in the C SDK. This document analyzes the impacts of choosing C99 as the minimum version of C to support in the C SDK.
 
 ### Non-goals
 


### PR DESCRIPTION
**- What I did**
- Wrote decision on minimum version of C SDK

Approval of this PR will approve C99 as our minimum version