### PR TITLE
ci: Refine lints

### DIFF
--- a/.github/workflows/pymarkdownlnt.yml
+++ b/.github/workflows/pymarkdownlnt.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Install and run linter
         run: |-
           python3 -m pip install --require-hashes -r tools/requirements.txt
-          pymarkdownlnt -d MD013,MD024 scan */*.md
+          pymarkdownlnt -c tools/pymarkdownlnt.conf scan */*.md

--- a/decisions/2023-01-pkam-per-app-and-device.md
+++ b/decisions/2023-01-pkam-per-app-and-device.md
@@ -126,6 +126,7 @@ format.
 
 #### Sequence diagram
 
+<!-- pyml disable-num-lines 43 md013-->
 ```mermaid
 sequenceDiagram
     participant FirstClient
@@ -240,6 +241,7 @@ delivered to apps which have permission to approve or deny the request
 
 #### Sequence diagram
 
+<!-- pyml disable-num-lines 52 md013-->
 ```mermaid
 sequenceDiagram
     participant NewClient

--- a/specification/at_protocol_specification.md
+++ b/specification/at_protocol_specification.md
@@ -158,6 +158,7 @@ in an atServer is bound by the config parameter "maxBufferSize".
    Metadata of a key should describe the following properties of the value
    being inserted.
 
+<!-- pyml disable-num-lines 16 md013-->
    | **Meta Attribute** | **Auto create?** | **Description**                                                                                                                |
    | ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
    | createdOn          | Yes              | Date and time when the key has been created.                                                                                   |
@@ -208,6 +209,7 @@ and size.
 
 An atServer should have the following standard keys:
 
+<!-- pyml disable-num-lines 19 md013-->
 | **Key**                    | **Description**                                               |
 | -------------------------- | ------------------------------------------------------------- |
 | public:publickey@          | Public key used by other atSigns for encryption.              |
@@ -432,6 +434,7 @@ The scan verb is used to see the keys in an atSign's secondary server.
 
 Following regex represents the syntax of the `scan` verb:
 
+<!-- pyml disable-next-line md013-->
 `r'^scan$|scan(:showhidden:(?<showhidden>true|false))?(:(?<forAtSign>@[^:@\s]+))?( (?<regex>\S+))?$'`
 
 **Response:**
@@ -464,6 +467,7 @@ update can only be run by the owner of an atServer on his/her own atServer.
 
 Following regex represents the syntax of the `update` verb:
 
+<!-- pyml disable-next-line md013-->
 `r'^update:(?:ttl:(?<ttl>\d+):)?(?:ttb:(?<ttb>\d+):)?(?:ttr:(?<ttr>(-?)\d+):)?(ccd:(?<ccd>true|false):)?((?:public:)|(@(?<for@sign>[^@:\s]-):))?(?<atKey>[^:@]((?!:{2})[^@])+)(?:@(?<@sign>[^@\s]-))? (?<value>.+$)'`
 
 **Example:**
@@ -509,6 +513,7 @@ If a key has been created for another atSign user, the atServer should honor
 
 **Options:**
 
+<!-- pyml disable-num-lines 9 md013-->
 | Option       | Required                                                      | Description                                                                                                                                                                                     |
 | ------------ | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `<ttl>`      | No                                                            | Time to live in milliseconds                                                                                                                                                                    |
@@ -569,6 +574,7 @@ configuration parameter.
 
 **OPTIONS:**
 
+<!-- pyml disable-num-lines 8 md013-->
 | Option       | Required                                        | Description                                                                                                                       |
 | ------------ | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `<ttl>`      | No                                              | Time to live in milliseconds                                                                                                      |
@@ -698,6 +704,7 @@ be returned, otherwise the public key has to be returned.
 
 **Options:**
 
+<!-- pyml disable-num-lines 5 md013-->
 | Option        | Required | Description                                                                                             |
 | ------------- | -------- | ------------------------------------------------------------------------------------------------------- |
 | `<operation>` | No       | `meta` - returns the metadata of the AtKey, `all` - returns both the data and the metadata of the AtKey |
@@ -763,6 +770,7 @@ by another atSign user.
 
 **Options:**
 
+<!-- pyml disable-num-lines 5 md013-->
 | Option        | Required | Description                                                                                             |
 | ------------- | -------- | ------------------------------------------------------------------------------------------------------- |
 | `<operation>` | No       | `meta` - returns the metadata of the AtKey, `all` - returns both the data and the metadata of the AtKey |
@@ -824,6 +832,7 @@ llookup should return the value as is.
 
 **Options:**
 
+<!-- pyml disable-num-lines 5 md013-->
 | Option        | Required | Description                                                                                             |
 | ------------- | -------- | ------------------------------------------------------------------------------------------------------- |
 | `<operation>` | No       | `meta` - returns the metadata of the AtKey, `all` - returns both the data and the metadata of the AtKey |
@@ -865,6 +874,7 @@ not exist will still respond with a commit id.
 
 **Options:**
 
+<!-- pyml disable-num-lines 7 md013-->
 | Option       | Required | Description                                                               |
 | ------------ | -------- | ------------------------------------------------------------------------- |
 | `:cached:`   | No       | Include `:cached:` if the key you are deleting is cached in your atServer |
@@ -903,6 +913,7 @@ statistics are provided:
 
 **Example:**
 
+<!-- pyml disable-next-line md013-->
 `data: [{"id":"1","name":"activeInboundConnections","value":"1"}, {"id":"2","name":"activeOutboundConnections","value":"0"}, {"id":"3","name":"lastCommitID","value":"1"}, {"id":"4","name":"secondaryStorageSize","value":12560}, {"id":"5","name":"topAtSigns","value":{"@bob":1}}, {"id":"6","name":"topKeys","value":{"publickey@alice":1}}]`
 
 Individual statistics can be retrieved using the respective Id.
@@ -1081,6 +1092,7 @@ by passing filter criteria as regex to `monitor` verb.
 
 **Options:**
 
+<!-- pyml disable-num-lines 3 md013-->
 | Option    | Required | Description                                                      |
 | --------- | -------- | ---------------------------------------------------------------- |
 | `<regex>` | No       | The regex to filter the notificaitons during the monitor session |
@@ -1099,6 +1111,7 @@ Regex: `^info(:brief)?$`
 
 `info`
 
+<!-- pyml disable-num-lines 2 md013-->
 ```json
 data:{"version":"3.0.28","uptimeAsWords":"1 hours 35 minutes 29 seconds","features":[{"name":"noop:","status":"Beta","description":"The No-Op verb simply does nothing for the requested number of milliseconds. The requested number of milliseconds may not be greater than 5000. Upon completion, the noop verb sends 'ok' as a response to the client.","syntax":"^noop:(?<delayMillis>\\d+)$"},{"name":"info:","status":"Beta","description":"The Info verb returns some information about the server including uptime and some info about available features. ","syntax":"^info(:brief)?$"}]}
 ```
@@ -1128,12 +1141,14 @@ After 123ms:
 
 `noop:5001`
 
+<!-- pyml disable-num-lines 2 md013-->
 ```text
 error:AT0022-Exception: noop:<durationInMillis> where the duration maximum is 5000 milliseconds
 ```
 
 ## Error Codes
 
+<!-- pyml disable-num-lines 21 md013-->
 | **Error Code** | **Error Message**                                     | **Description**                                                                                                                                         |
 | -------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | AT0001         | Server exception                                      | Exception occurs when there is an issue while starting the server.                                                                                      |

--- a/tools/pymarkdownlnt.conf
+++ b/tools/pymarkdownlnt.conf
@@ -1,0 +1,1 @@
+{"plugins": {"md024": {"siblings_only": True}}}

--- a/usage-examples/how-to-exchange-encrypted-data.md
+++ b/usage-examples/how-to-exchange-encrypted-data.md
@@ -230,6 +230,7 @@ This is created the first time one AtSign tries to communicate with another.
 Sequence diagram of the process of sending and receiving data between two
 AtSigns.
 
+<!-- pyml disable-num-lines 15 md013-->
 ```mermaid
 sequenceDiagram
     participant A as Alice


### PR DESCRIPTION
We have been suppressing two rules:

* md013 - long lines - needed because tables contain long lines
* md024 - multiple headings with the same content - as we repeat (sub)headings in some docs

The first is the most problematic, as it means new docs with long lines that aren't necessary still pass tests.

**- What I did**

* Individual pragmas around where we do need long lines
* Config file to allow repeat headings in siblings only
* Rework workflow to use config file

**- How I did it**

I wanted to use a command line setting rather than config file, but couldn't get it to work hence config file and https://github.com/jackdewinter/pymarkdown/issues/1000

**- How to verify it**

Clean ci run against this PR

**- Description for the changelog**

ci: Refine lints
