### PR TITLE
ci: Use command line option rather than conf file for pymarkdownlnt

### DIFF
--- a/.github/workflows/pymarkdownlnt.yml
+++ b/.github/workflows/pymarkdownlnt.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Install and run linter
         run: |-
           python3 -m pip install --require-hashes -r tools/requirements.txt
-          pymarkdownlnt -c tools/pymarkdownlnt.conf scan */*.md
+          pymarkdownlnt -s 'plugins.md024.siblings_only=$!True' scan */*.md

--- a/tools/pymarkdownlnt.conf
+++ b/tools/pymarkdownlnt.conf
@@ -1,1 +1,0 @@
-{"plugins": {"md024": {"siblings_only": True}}}


### PR DESCRIPTION
Removed conf file based workaround based on learning from https://github.com/jackdewinter/pymarkdown/issues/1000

**- What I did**

* moved config from conf file to command line flag
* removed conf file

**- How to verify it**

Linter will run without errors (on this PR)

**- Description for the changelog**

ci: Use command line option rather than conf file for pymarkdownlnt
