### PR TITLE
docs(spec): rewrite Atsign Protocol Specification

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,5 +1,5 @@
 root: ./
 
 structure:
-  readme: specification/at_protocol_specification.md
+  readme: specification/atsign_protocol_specification.md
   summary: SUMMARY.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,79 @@
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+

--- a/README.md
+++ b/README.md
@@ -1,44 +1,37 @@
 <!-- pyml disable-num-lines 4 md033-->
 <h1><a href="https://atsign.com#gh-light-mode-only">
 <img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only"
-alt="The Atsign Foundation"></a><a href="https://atsign.com#gh-dark-mode-only">
+ alt="The Atsign Foundation"></a><a href="https://atsign.com#gh-dark-mode-only">
 <img width=250px src="https://atsign.com/wp-content/uploads/2023/08/atsign-logo-horizontal-reverse2022-Color.svg#gh-dark-mode-only"
-alt="The Atsign Foundation"></a></h1>
+ alt="The Atsign Foundation"></a></h1>
 
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://github.com/atsign-foundation/at_protocol/blob/trunk/LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/atsign-foundation/at_protocol/badge)](https://securityscorecards.dev/viewer/?uri=github.com/atsign-foundation/at_protocol&sort_by=check-score&sort_direction=desc)
 
-# The atProtocol Specification
+# The Atsign Protocol Specification
 
 This repository is home to the
-[open source specification for The atProtocol](specification/at_protocol_specification.md)
-as well as supporting documentation.
+[open source specification for The Atsign Protocol](specification/atsign_protocol_specification.md)
+as well as supporting documentation. App developers building on the
+protocol via the Dart `at_client_sdk` may prefer the shorter
+[Building on the Atsign Protocol](specification/building_on_the_atsign_protocol.md)
+pointer card.
 
 ## This repo is for anyone interested in
 
-1. Understanding what The atProtocol is and how it works.
+1. Understanding what The Atsign Protocol is and how it works.
 2. Contributing to the specification with suggestions, edits or proposed
-changes.
-3. Implementing another reference implementation that us interoperatable with
-others.
+   changes.
+3. Implementing another atClient or atServer that is interoperable with
+   others.
 
 The intent of the specification is to define the actors, roles, responsibilities
-required to implement a working system that is atProtocol compliant.
+required to implement a working system that is Atsign Protocol compliant.
 
-The specification itself is a simple markdown document that is easiy to view
+The specification itself is a simple Markdown document that is easy to view
 and edit.
 
 ### Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidance on how to
 submit changes and make pull requests.
-
-## Maintainers
-
-This document was created and is maintained by:
-- [Colin Constable](https://github.com/cconstab)
-- [Murali Dharan](https://github.com/murali-shris)
-- [Kevin Nickels](https://github.com/nickelskevin)
-- [Jagannadh Vanghuri](https://github.com/VJag)
-
-You can ask any of the above to review/approve any change requests.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,6 +1,7 @@
 # Table of contents
 
-* [atProtocol Specification](specification/at\_protocol\_specification.md)
+* [Atsign Protocol Specification](specification/atsign\_protocol\_specification.md)
+* [Building on the Atsign Protocol](specification/building\_on\_the\_atsign\_protocol.md)
 
 ## Usage Examples
 

--- a/info/license.md
+++ b/info/license.md
@@ -1,7 +1,7 @@
 # Primary License
 
 The primary software license used by The Atsign Foundation's projects,
-including atProtocol implementations is the BSD 3-Clause License.
+including Atsign Protocol implementations is the BSD 3-Clause License.
 
 ## License Copy
 

--- a/specification/atsign_protocol_specification.md
+++ b/specification/atsign_protocol_specification.md
@@ -1,0 +1,2267 @@
+# Atsign Protocol Specification
+
+This document specifies the **Atsign Protocol** at the level required to
+implement either side of the wire — an atClient or an atServer — in any
+language. Every byte that crosses a TCP socket between an atClient,
+atServer, or atDirectory is in scope. Higher-level concerns that are
+client-only (file formats, key derivation, query languages) are out of
+scope unless they affect what is on the wire.
+
+The companion document
+[`building_on_the_atsign_protocol.md`](./building_on_the_atsign_protocol.md)
+is the entry-point for **application developers** building on the
+Atsign Protocol via the Dart `at_client_sdk`. If you are writing an app
+rather than a protocol implementation, start there.
+
+The canonical source for protocol behaviour is the implementation in
+the [`at_client_sdk`](https://github.com/atsign-foundation/at_client_sdk)
+and [`at_server`](https://github.com/atsign-foundation/at_server)
+repositories. Where this document and that source disagree, the source
+wins and this document is a bug. Pull requests welcomed.
+
+---
+
+## Table of contents
+
+1. [Introduction](#1-introduction)
+2. [Deployment topologies](#2-deployment-topologies)
+3. [Transport](#3-transport)
+4. [Framing](#4-framing)
+5. [The atSign identity model](#5-the-atsign-identity-model)
+6. [The atKey model](#6-the-atkey-model)
+7. [The metadata fragment](#7-the-metadata-fragment)
+8. [The atDirectory protocol](#8-the-atdirectory-protocol)
+9. [Authentication](#9-authentication)
+10. [CRUD verbs](#10-crud-verbs)
+11. [Notification verbs](#11-notification-verbs)
+12. [The sync verb](#12-the-sync-verb)
+13. [Server-admin and utility verbs](#13-server-admin-and-utility-verbs)
+14. [End-to-end encryption](#14-end-to-end-encryption)
+15. [The inter-atServer protocol](#15-the-inter-atserver-protocol)
+16. [Worked flows](#16-worked-flows)
+17. [Errors](#17-errors)
+18. [Glossary](#18-glossary)
+19. [Appendix A — Verb reference](#appendix-a--verb-reference)
+20. [Appendix B — Legacy and deprecated](#appendix-b--legacy-and-deprecated)
+21. [Appendix C — Significant near-term projects](#appendix-c--significant-near-term-projects)
+22. [Appendix D — Inconsistencies and quirks](#appendix-d--inconsistencies-and-quirks)
+
+---
+
+## 1. Introduction
+
+The Atsign Protocol is a text-based, line-oriented, request/response
+protocol over TLS. Three roles participate:
+
+- **atClient** — software acting on behalf of an atSign owner. Talks to
+  exactly one atServer at a time (the owner's atServer or a
+  remote-owner's atServer for cross-atSign reads/writes).
+- **atServer** — the personal server for one atSign. Stores that
+  atSign's keys (encrypted blobs at rest), serves them on request,
+  delivers notifications, and connects out to other atServers when its
+  owner's atClient asks for cross-atSign data.
+- **atDirectory** — a lookup service that maps an atSign to the
+  `host:port` of its atServer. Conceptually similar to DNS.
+
+The protocol is built around a small set of **verbs** — single-line
+commands a client sends to a server. Each verb has a regex-defined
+syntax. Servers respond with a single line of `data:…` or `error:…`,
+followed by a prompt that frames the next request. Two verbs (`monitor`
+and the legacy `stream`) keep the connection open for streamed
+responses; everything else is single-shot.
+
+End-to-end encryption is **entirely an atClient concern**. atServers
+store opaque ciphertext and opaque metadata fields, and never see
+plaintext values. Server-side filtering on values is therefore
+architecturally impossible — see [§14](#14-end-to-end-encryption).
+
+### For implementers — read these first
+
+Two appendices are load-bearing for anyone implementing this
+specification:
+
+- **[Appendix C — Significant near-term projects](#appendix-c--significant-near-term-projects)**
+  enumerates active workstreams that will change parts of this
+  specification within the next few releases (post-quantum
+  cryptography, fast-sync / "fsync", new atKeys structure, pluggable
+  encryption, canonical conformance test suite, etc.). Read this
+  before committing to a long-lived implementation choice.
+- **[Appendix D — Inconsistencies and quirks](#appendix-d--inconsistencies-and-quirks)**
+  enumerates the places where the wire reality is surprising — error
+  separators that aren't uniform, response shapes that differ
+  per-verb, semantics that flip on auth state, and similar gotchas.
+  Read this if your implementation is failing in ways that the
+  per-verb sections don't seem to predict.
+
+### Spelling and capitalisation
+
+The protocol's name is **Atsign Protocol** (capital A, capital P,
+single-spaced). The domain terms are:
+
+- `atSign` — an identity like `@alice`
+- `atServer` — the personal server for an atSign
+- `atDirectory` — the directory service
+- `atKey` — a key in an atServer's keystore
+- `atClient` — software talking to atServers
+
+Preserve those capitalisations exactly in code and docs.
+
+---
+
+## 2. Deployment topologies
+
+`atDirectory` and `atServer` are **addresses, not endpoints**. The
+default atDirectory for the public Atsign Protocol is at
+`root.atsign.org:64`, but any atDirectory address may be used. An
+atClient learns its atServer's address by querying its atDirectory; an
+atServer learns another atServer's address the same way (via its own
+atDirectory pointer, which need not be the same one).
+
+Three deployment modes are commonly seen:
+
+1. **Public hosted.** Default. Clients use `root.atsign.org:64` as
+   their atDirectory; atSigns are hosted by Atsign on shared
+   infrastructure. This is what `at_register` and `at_activate` produce
+   out of the box.
+2. **Self-hosted atServer with public atDirectory.** An organisation
+   runs its own atServers, but the atSigns are still resolvable via
+   `root.atsign.org:64`. The atDirectory entry points at the
+   organisation's hosts.
+3. **Fully self-hosted (split-horizon).** An organisation runs its own
+   atDirectory **and** its own atServers, with atSign registration and
+   provisioning entirely under its control. atSigns hosted in this
+   topology are not resolvable on the public Atsign Protocol; clients
+   must be configured with the alternate atDirectory address. This is
+   the model for a hermetically-sealed enterprise deployment.
+
+Implementations MUST allow the atDirectory address to be configured.
+A hard-coded `root.atsign.org:64` is not Atsign-Protocol-compliant.
+
+---
+
+## 3. Transport
+
+### 3.1 atDirectory
+
+- **Transport:** TCP.
+- **TLS:** **One-way TLS** — the atDirectory presents a server
+  certificate; the client does not present one.
+- **Default port:** `64`.
+- **Default host:** `root.atsign.org` (configurable).
+
+### 3.2 atServer
+
+- **Transport:** TCP.
+- **TLS:** **One-way TLS by default.** Some deployments require client
+  certificates (mTLS) for atServer-to-atServer connections — the
+  outbound connection factory chooses based on configuration. mTLS is
+  not used between atClients and atServers in the default
+  configuration.
+- **Port:** Per-atSign. Discovered via the atDirectory. The atDirectory
+  response is the canonical source for the host and port to connect
+  to.
+
+### 3.3 Connection lifecycle
+
+1. Client opens TCP connection.
+2. TLS handshake; server certificate is validated against the trusted
+   roots (and optionally a pinned `cacert.pem`).
+3. **No pre-banner.** The server does not send a greeting line; it
+   waits for the client's first verb.
+4. Client sends verb, terminated by `\n`.
+5. Server responds with `data:…\n@…@` or `error:…\n@…@`. The trailing
+   `@…@` (or bare `@` before authentication) is the **prompt** — see
+   [§4](#4-framing).
+6. Steps 4–5 repeat. Either side may close the connection at any time;
+   the client may signal a graceful close with `@exit\n` (atDirectory
+   only) or by simply closing the socket.
+
+### 3.4 Idle and timeout behaviour
+
+- atClient default outbound idle timeout: **600 000 ms** (10 minutes).
+  Source: `at_lookup/lib/src/connection/outbound_connection_impl.dart`.
+- atClient default per-response wait: **90 000 ms**, with a
+  **10 000 ms** transient-wait between data packets. Source:
+  `at_lookup/lib/src/connection/outbound_message_listener.dart`.
+- atServer default inbound and outbound idle limits are configurable
+  per deployment (see `inbound_idle_time_millis`,
+  `outbound_idle_time_millis`).
+
+When the server-side idle timeout fires, the server closes the
+connection without warning. Long-lived `monitor` connections must be
+within the configured idle limit, or the server side will need to
+disable idle-close for that connection class.
+
+---
+
+## 4. Framing
+
+### 4.1 Line terminator
+
+All client-to-server and server-to-server commands end with a single
+**LF** (`\n`, ASCII 10). CR (`\r`) is not part of the protocol; some
+older atDirectory implementations emit `\r\n@`, and clients tolerate
+both.
+
+### 4.2 Response delimiter (the "prompt")
+
+A server response is followed by a **prompt** that frames the next
+client request. The prompt is one of:
+
+| Connection state                          | Prompt           |
+| ----------------------------------------- | ---------------- |
+| Unauthenticated                           | `@`              |
+| Authenticated as the server's own atSign  | `@<atSign>@`     |
+| `pol`-authenticated as another atSign     | `<fromAtSign>@`  |
+
+The prompt is appended to the response line preceded by `\n`. Clients
+detect "response complete" by scanning for the byte sequence `\n@`.
+Source: `at_lookup/lib/src/connection/outbound_message_listener.dart`
+treats `\n` followed by `@` as the frame boundary.
+
+```
+data:42\n@alice@
+^^^^^^^^^^^^^^^^^
+| response data | prompt
+```
+
+Note: the prompt is **part of the framing**, not the response payload.
+A client implementation that includes `\n@…@` in its captured response
+is parsing incorrectly.
+
+### 4.3 Charset
+
+UTF-8. atKeys, values, and metadata are all UTF-8 strings on the wire.
+
+### 4.4 Newline escaping in values
+
+Because `\n` is the framing terminator, an atServer rewrites embedded
+newlines in **public** data values: `\n` becomes the literal
+six-character sequence `~NL~` on the wire. Clients writing values that
+contain newlines apply the same escape; clients reading public values
+reverse it. The escape is not applied to encrypted (binary)
+ciphertext — that is base64-encoded and so contains no `\n` to begin
+with.
+
+### 4.5 Binary values
+
+Binary values cross the wire base64-encoded. The metadata flag
+`isBinary:true` declares that the value, once decoded, is binary.
+`isEncrypted:true` declares it is ciphertext. The two are independent
+and both can be true. See [§7](#7-the-metadata-fragment).
+
+### 4.6 Maximum value size
+
+Bounded by the atServer's `bufferLimit` configuration parameter.
+Implementations should expose the limit via the `stats` verb. Clients
+that exceed the limit receive `error:AT0005-Buffer limit exceeded` and
+the connection is closed.
+
+### 4.7 Pipelining
+
+The protocol is request-response with a single in-flight verb per
+connection. A client must not send a second verb before reading the
+first verb's complete response (terminated by the prompt). The
+exception is `monitor`, which streams notifications continuously and
+optionally accepts request-response interleaving when `:multiplexed:`
+is set — see [§11.7](#117-monitor).
+
+---
+
+## 5. The atSign identity model
+
+An **atSign** is a unique identifier of the form `@<name>` where
+`<name>` matches `[^@:\s]+`. Comparison is case-preserving but
+case-insensitive on the wire — `@Alice` and `@alice` resolve to the
+same identity (atServers normalise to lowercase before keystore
+lookup).
+
+The maximum atSign length is **55 characters** including the leading
+`@`. Anything longer is invalid.
+
+### 5.1 Lifecycle phases
+
+The full lifecycle of an atSign from registration to active use breaks
+into three phases. The `at_auth` package documents this in detail; the
+phases are summarised here because each produces credentials that
+appear on the wire.
+
+1. **Register.** The atSign is created on the atDirectory's registrar.
+   Output: a one-time **CRAM secret** delivered to the registered email
+   address. No cryptographic keys exist yet.
+2. **Onboard.** The atClient CRAM-authenticates exactly once, generates
+   the atSign's master keypairs (PKAM signing, encryption,
+   self-encryption), publishes the public halves to the atServer, and
+   stores the private halves locally (`.atKeys` file or device
+   keychain). After onboarding, the CRAM secret is no longer accepted.
+3. **Authenticate (per app).** Subsequent apps authenticate via
+   **APKAM enrollment** — they request a scoped key set bound to a
+   namespace permission map (e.g. `{'todos': 'rw'}`); the master-keys
+   holder approves; the atServer issues new scoped credentials.
+   APKAM-issued keys are revocable.
+
+CRAM is bootstrap-only. After Phase 2, all client authentication is
+PKAM (with or without APKAM scoping). See [§9](#9-authentication).
+
+---
+
+## 6. The atKey model
+
+A key in the atServer's keystore is an **atKey** — a structured string
+whose shape encodes its visibility and ownership. There are five key
+shapes plus two augmentations.
+
+### 6.1 The five shapes
+
+| Shape       | Wire format                              | Visibility                                                  |
+| ----------- | ---------------------------------------- | ----------------------------------------------------------- |
+| Public      | `public:<key>[.<namespace>]@<owner>`     | Any atSign (no auth needed via `plookup`)                   |
+| Self        | `<key>[.<namespace>]@<owner>`            | Owner only                                                  |
+| Shared      | `@<recipient>:<key>[.<namespace>]@<owner>` | Owner and `<recipient>` only                              |
+| Local       | `local:<key>[.<namespace>]@<owner>`      | Owner only; **never synced** to a remote atServer           |
+| Private     | `privatekey:<key>[.<namespace>]@<owner>` | Owner only; not enumerated by `scan` (system keys)         |
+
+### 6.2 Augmentations
+
+- **Hidden** — if the `<key>` part starts with `_`, the key is not
+  returned by `scan` unless the caller passes `:showhidden:true`.
+  Public, self, and shared keys may all be hidden.
+- **Cached** — a copy of a remote-owned shared or public key, stored on
+  the recipient's atServer for offline / fast access. Wire format:
+  `cached:public:<key>@<owner>` or `cached:@<recipient>:<key>@<owner>`.
+  The recipient's atServer refreshes the cache per the original key's
+  `ttr` (time-to-refresh) and deletes it on owner-side delete if `ccd`
+  is set.
+
+### 6.3 Namespace
+
+A trailing `.<namespace>` segment scopes the key to an application or
+domain (e.g. `phone.wavi`, `email.myapp`). APKAM enrollments grant
+permissions per namespace, so the namespace is part of the
+authorisation surface, not a free-form annotation.
+
+The namespace can be omitted when the atKey represents an
+infrastructural item (atSign-wide encryption keys, e.g.
+`public:publickey@alice`).
+
+### 6.4 Key length
+
+The maximum on-wire length of an atKey is **255 characters**
+inclusive of all segments and separators. Compute against this hard
+cap, not a typical size — atSigns alone may consume up to 55
+characters of the budget.
+
+### 6.5 Reserved keys
+
+Every atServer carries a set of system keys created during onboarding.
+These are required for the protocol to function and have stable names:
+
+| Reserved key                        | Purpose                                                                 |
+| ----------------------------------- | ----------------------------------------------------------------------- |
+| `public:publickey@<atSign>`         | Encryption public key. Used by other atSigns to encrypt to this owner.  |
+| `public:signing_publickey@<atSign>` | PKAM/pol signing public key. Used to verify pol challenges.             |
+| `privatekey:at_pkam_publickey`      | PKAM authentication public key (single-key model; legacy).              |
+| `privatekey:at_pkam_privatekey`     | PKAM authentication private key (in the on-disk `.atKeys` file).        |
+| `privatekey:privatekey`             | Encryption private key (`.atKeys`).                                     |
+| `privatekey:self_encryption_key`    | Self-encryption symmetric key (`.atKeys`).                              |
+| `privatekey:at_secret`              | CRAM secret. Rotated to the keystore at onboarding; not used after.     |
+| `<atSign>:shared_key@<atSign>`      | Symmetric key wrapping shared-with values. Not actually used; reserved. |
+| `private:blocklist@<atSign>`        | List of atSigns blocked by `config:block:add`.                          |
+
+APKAM-issued keys live under the `__pkams` and `__manage` reserved
+namespaces.
+
+### 6.6 atKey parsing examples
+
+| Wire form                                  | Shape  | Hidden? | Cached? |
+| ------------------------------------------ | ------ | ------- | ------- |
+| `public:phone.wavi@alice`                  | Public | No      | No      |
+| `public:_diagnostics@alice`                | Public | Yes     | No      |
+| `phone.wavi@alice`                         | Self   | No      | No      |
+| `@bob:phone.wavi@alice`                    | Shared | No      | No      |
+| `@bob:_handshake.wavi@alice`               | Shared | Yes     | No      |
+| `cached:public:publickey@alice`            | Public | No      | Yes     |
+| `cached:@bob:phone.wavi@alice`             | Shared | No      | Yes     |
+| `local:cache.myapp@alice`                  | Local  | No      | No      |
+| `privatekey:at_pkam_publickey`             | Private | —      | —       |
+
+---
+
+## 7. The metadata fragment
+
+A **metadata fragment** is a sequence of `:tag:value` segments embedded
+in the `update`, `update:meta`, and `notify` verbs. Every metadata
+field a key can carry has a corresponding wire tag. Unrecognised tags
+must be rejected by an atServer (servers tighten the surface; clients
+should not send tags they don't understand).
+
+### 7.1 Catalogue
+
+Source of truth: `at_commons/lib/src/verb/syntax.dart`'s
+`metadataFragment`.
+
+| Wire tag           | Type        | Description                                                                                              |
+| ------------------ | ----------- | -------------------------------------------------------------------------------------------------------- |
+| `ttl`              | int (ms)    | Time-to-live. Key auto-deletes `ttl` ms after creation. `0` or omitted = never expires.                 |
+| `ttb`              | int (ms)    | Time-to-birth. Key is invisible to lookups for `ttb` ms after creation.                                  |
+| `ttr`              | int (ms)    | Time-to-refresh for cached copies. `-1` = cache forever; positive = re-fetch interval.                   |
+| `ccd`              | bool        | Cascade-delete. If `true`, deleting the original key deletes its cached copies.                          |
+| `cAt`              | ISO 8601    | `createdAt` — UTC timestamp of creation. Regex: `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z` (fractional seconds optional). |
+| `uAt`              | ISO 8601    | `updatedAt` — UTC timestamp of most recent update.                                                       |
+| `eAt`              | ISO 8601    | `expiresAt` — derived from `cAt + ttl`. Normally server-emitted; clients can also set explicitly (e.g. on sync replay). |
+| `aAt`              | ISO 8601    | `availableAt` — derived from `cAt + ttb`. Same write semantics as `eAt`.                                  |
+| `dataSignature`    | string      | Signature over a public value, signed by the owner's signing private key. Verifies authenticity.        |
+| `sharedKeyStatus`  | enum        | Lifecycle status of a shared key: `localUpdated`, `remoteUpdated`, `sharedWithNotified`, etc.            |
+| `isBinary`         | bool        | `true` if the value is binary (base64-encoded on the wire).                                             |
+| `isEncrypted`      | bool        | `true` if the value is ciphertext.                                                                       |
+| `sharedKeyEnc`     | string      | The shared symmetric key, RSA-encrypted to the recipient's encryption public key. Inline in metadata.   |
+| `pubKeyHash`       | string      | Hash of the recipient public key that encrypted `sharedKeyEnc`. Lets the recipient detect key rotation. |
+| `pubKeyCS`         | string      | **Deprecated.** Predecessor to `pubKeyHash`. New code must emit `pubKeyHash` + `hashingAlgo`.            |
+| `hashingAlgo`      | enum        | Algorithm for `pubKeyHash`: `sha256` or `sha512`.                                                       |
+| `encoding`         | string      | Encoding of the value if not raw UTF-8 (e.g. `base64`).                                                 |
+| `encKeyName`       | string      | Name of the symmetric key used to encrypt the value (resolves to a key name in the owner's keystore).   |
+| `encAlgo`          | string      | Symmetric algorithm used to encrypt the value (e.g. `AES/SIC/PKCS7Padding`).                            |
+| `ivNonce`          | string      | Base64 IV / nonce used in symmetric encryption of the value.                                            |
+| `skeEncKeyName`    | string      | Name of the public key that wrapped `sharedKeyEnc`.                                                      |
+| `skeEncAlgo`       | string      | Algorithm used to wrap `sharedKeyEnc` (default `RSA`).                                                  |
+| `immutable`        | bool        | If `true`, the key cannot be updated; deletion requires `:force:`.                                      |
+
+Negative integer values for `ttl`/`ttb` are accepted by the regex (the
+syntax allows `(-?)\d+`) but server-side semantics are documented at
+the constants level — typically only `ttr:-1` ("cache forever") is a
+useful negative.
+
+### 7.2 Tag ordering
+
+Metadata tags appear in a defined order in the regex. Implementations
+producing wire commands SHOULD emit tags in regex-declared order:
+`ttl, ttb, ttr, ccd, cAt, uAt, eAt, aAt, dataSignature,
+sharedKeyStatus, isBinary, isEncrypted, sharedKeyEnc, pubKeyCS,
+pubKeyHash, hashingAlgo, encoding, encKeyName, encAlgo, ivNonce,
+skeEncKeyName, skeEncAlgo, immutable`. Servers parse via the canonical
+regex which enforces this order; deviating produces a syntax error.
+
+---
+
+## 8. The atDirectory protocol
+
+The atDirectory speaks a tiny subset of the protocol: it accepts an
+atSign and returns the address of that atSign's atServer.
+
+### 8.1 Connect
+
+Open a TLS connection to the atDirectory address (default
+`root.atsign.org:64`). The atDirectory sends a single `@` byte as its
+prompt.
+
+### 8.2 Lookup
+
+Send the atSign followed by `\n`. Either form is accepted:
+
+```
+@alice\n
+alice\n
+```
+
+### 8.3 Response
+
+Two possible replies:
+
+- **Found:** `<host>:<port>\n@` — `host` is a hostname or IP, `port` is
+  the atServer's TLS port for that atSign.
+- **Not found:** `null\n@`
+
+Some atDirectory implementations emit `\r\n@` instead of `\n@`;
+implementations should accept both.
+
+### 8.4 Disconnect
+
+The client signals a graceful close with `@exit\n`. After sending,
+flush and close the socket. No response is expected.
+
+### 8.5 Worked example
+
+```
+C: <TLS handshake>
+S: @
+C: @alice\n
+S: alice.atsign.com:6589\n@
+C: @exit\n
+C: <socket close>
+```
+
+The `@exit` verb is the only verb the atDirectory supports beyond
+lookups; any other input is treated as an atSign to look up.
+
+---
+
+## 9. Authentication
+
+The atServer recognises three authentication mechanisms, all built on
+the same `from`-then-prove choreography. Modern atClients use **APKAM**
+exclusively, with **CRAM** appearing only during one-time onboarding.
+
+### 9.1 The `from` verb
+
+`from` is the first verb on every atServer connection. It tells the
+server which atSign is connecting and, for non-self connections, who
+the server should expect to authenticate via `pol`.
+
+**Syntax**
+
+```
+from:<atSign>[:clientConfig:<clientConfig-json>]
+```
+
+Source: `at_commons/lib/src/verb/syntax.dart`:
+```
+^from:(?<atSign>@?[^:@\s]+)(:clientConfig:(?<clientConfig>\{.+\}))?$
+```
+
+The `clientConfig` JSON is optional and free-form. The atServer reads
+the following recognised fields and stores them on the connection
+metadata:
+
+| Field        | Purpose                                                    |
+| ------------ | ---------------------------------------------------------- |
+| `version`    | Client SDK version string                                  |
+| `clientId`   | Unique client / device identifier                          |
+| `appName`    | Application name                                           |
+| `appVersion` | Application version                                        |
+| `platform`   | OS or platform tag (e.g. `iOS`, `Android`, `linux`)        |
+
+Unrecognised fields are ignored.
+
+**Response** — the server generates a UUIDv4 challenge and a session
+ID and stores the challenge under
+`<keyPrefix><sessionId><fromAtSign>` (with TTL 60 s), where
+`keyPrefix` is `private:` if the connecting atSign matches the
+server's own atSign (self-connect) and `public:` otherwise (this
+matters for `pol`, which retrieves the challenge via `plookup`).
+
+The response payload is:
+
+```
+data:<sessionId><fromAtSign>:<proof>      # if self-connect
+data:proof:<sessionId><fromAtSign>:<proof> # if cross-atSign connect
+```
+
+— each followed by the unauthenticated prompt `\n@`.
+
+Source: `at_secondary_server/lib/src/verb/handler/from_verb_handler.dart`
+lines 74–103.
+
+**Example** — self-connect by `@alice` to `@alice`'s atServer:
+
+```
+C: from:@alice\n
+S: data:_4af24c03-d732-48f8-a9a2-570e8fb6a01c@alice:d6cac849-9c29-42b0-b0c5-493db62728b9\n@
+```
+
+### 9.2 CRAM (`cram`)
+
+CRAM is the **bootstrap-only** authentication mechanism. After
+onboarding, the CRAM secret is no longer the canonical credential and
+clients must use PKAM/APKAM. CRAM remains in the protocol because
+onboarding from a fresh atServer requires a credential that exists
+before any keypair has been generated.
+
+**Syntax**
+
+```
+cram:<digest>
+```
+
+Source:
+```
+^cram:(?<digest>.+$)
+```
+
+**Digest computation** — the client takes the `from` response, strips
+the leading `data:` prefix, and computes:
+
+```
+digest = sha512_hex( utf8( <cramSecret> + <strippedFromResponse> ) )
+```
+
+For a self-connect, `<strippedFromResponse>` is
+`<sessionId><atSign>:<proof>` — the entire body with no further
+parsing. Source: `at_lookup/lib/src/at_lookup_impl.dart` lines 540–544.
+
+**Response**
+
+- Success: `data:success\n@<atSign>@`
+- Failure: `error:AT0401-Client authentication failed\n@` (connection
+  may close)
+
+After success the connection is **authenticated as owner**.
+
+### 9.3 PKAM (`pkam`)
+
+Plain PKAM is the underlying signature-based authentication that APKAM
+extends. A client running plain PKAM holds the master signing private
+key directly.
+
+**Syntax**
+
+```
+pkam:[signingAlgo:<rsa2048|ecc_secp256r1>:][hashingAlgo:<sha256|sha512>:][enrollmentId:<id>:]<signature>
+```
+
+Source:
+```
+^pkam:(signingAlgo:(?<signingAlgo>ecc_secp256r1|rsa2048):)?(hashingAlgo:(?<hashingAlgo>sha256|sha512):)?(enrollmentId:(?<enrollmentId>.+):)?(?<signature>.+$)
+```
+
+**Signature computation** — the client signs the `from` challenge
+(everything the `from` response payload contained, less any leading
+`data:`) with the owner's signing private key, base64-encodes the
+result, and sends it as `<signature>`.
+
+Defaults: `signingAlgo:rsa2048`, `hashingAlgo:sha256`. The `enrollmentId`
+is omitted for plain PKAM; an APKAM-issued credential includes the
+enrollment's ID so the atServer can look up the namespace permission
+map.
+
+**Response** — same as CRAM: `data:success` on success,
+`error:AT0401-…` on failure.
+
+### 9.4 APKAM (`enroll`, `otp`, `keys`)
+
+APKAM (Application PKAM) is the modern authentication mechanism. It
+issues a per-app, per-device keypair scoped to a namespace permission
+map, and supports approval, denial, revocation, and expiry by the
+atSign owner.
+
+A high-level flow:
+
+1. **Bootstrap atSign** — the new app generates a fresh APKAM keypair
+   and a fresh APKAM symmetric key.
+2. **Get an OTP** — the user, on a session already authenticated as
+   owner, runs `otp:get` and reads the OTP to the new app.
+3. **`enroll:request`** — the new app submits the request, including
+   its APKAM public key, the OTP, the namespace permission map, and
+   the APKAM symmetric key encrypted with the **default encryption
+   public key** (so only an owner-keys holder can decrypt it).
+4. **`enroll:approve`** — the owner-keys holder fetches the request,
+   decrypts the APKAM symmetric key, then sends back the
+   default encryption private key and self-encryption key, each
+   encrypted with the now-shared APKAM symmetric key (with IVs).
+5. **PKAM-with-enrollmentId** — the new app authenticates as usual via
+   `from` + `pkam`, passing `enrollmentId:<id>` so the atServer scopes
+   the connection to the granted namespaces.
+
+#### 9.4.1 The `enroll` verb
+
+**Syntax**
+
+```
+enroll:<operation>[:force][:<enrollParams-json>]
+```
+
+Source:
+```
+^enroll:(?<operation>(?:(request|approve|deny|revoke|list|fetch|unrevoke|delete)))(:(?<force>force))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$
+```
+
+`<enrollParams>` is the JSON serialisation of the `EnrollParams` shape
+(`at_commons/lib/src/verb/enroll_params.dart`):
+
+| Field                                  | Used by         | Description                                                                                  |
+| -------------------------------------- | --------------- | -------------------------------------------------------------------------------------------- |
+| `enrollmentId`                         | approve/deny/revoke/fetch/delete/unrevoke | UUID of the enrollment.                                                  |
+| `appName`                              | request         | Application name, e.g. `"todos"`.                                                           |
+| `deviceName`                           | request         | Unique device identifier.                                                                    |
+| `namespaces`                           | request         | Map of `namespace → permission` (`r`, `w`, `rw`, `rwx`).                                    |
+| `otp`                                  | request         | One-time password from `otp:get`.                                                            |
+| `apkamPublicKey`                       | request         | New device's APKAM public key (PEM or base64).                                              |
+| `encryptedAPKAMSymmetricKey`           | request         | New device's APKAM symmetric key, RSA-encrypted to the default encryption public key.       |
+| `encryptedDefaultEncryptionPrivateKey` | approve         | Owner's encryption private key, AES-encrypted with the APKAM symmetric key.                 |
+| `encPrivateKeyIV`                      | approve         | IV (base64) for the line above.                                                              |
+| `encryptedDefaultSelfEncryptionKey`    | approve         | Owner's self-encryption key, AES-encrypted with the APKAM symmetric key.                    |
+| `selfEncKeyIV`                         | approve         | IV (base64) for the line above.                                                              |
+| `enrollmentStatusFilter`               | list            | Optional list of statuses to filter on: `pending`, `approved`, `denied`, `revoked`, `expired`. |
+| `apkamKeysExpiryDuration`              | request         | ISO-8601 duration: lifetime of the APKAM credentials before forced re-enrollment.            |
+
+**Operations and responses**
+
+| Operation   | Response payload                                                       |
+| ----------- | ---------------------------------------------------------------------- |
+| `request`   | `data:{"enrollmentId":"<uuid>","status":"pending"}`                    |
+| `approve`   | `data:{"enrollmentId":"<uuid>","status":"approved"}`                   |
+| `deny`      | `data:{"enrollmentId":"<uuid>","status":"denied"}`                     |
+| `revoke`    | `data:{"enrollmentId":"<uuid>","status":"revoked"}` (`:force:` to revoke own enrollment) |
+| `unrevoke`  | `data:{"enrollmentId":"<uuid>","status":"approved"}`                   |
+| `delete`    | `data:{"enrollmentId":"<uuid>","status":"deleted"}`                    |
+| `fetch`     | `data:{ <full enrollment record JSON> }`                               |
+| `list`      | `data:{"<enrollKey>":{<enrollment record JSON>}, …}`                   |
+
+#### 9.4.2 The `otp` verb
+
+```
+otp:get[:ttl:<ms>]
+otp:put:<otp>[:ttl:<ms>]
+```
+
+Source:
+```
+^otp:(?<operation>get|put)(:(?<otp>(?<=put:)\w{6,}))?(:(?:ttl:(?<ttl>\d+)))?$
+```
+
+- `otp:get` — owner-authenticated. Returns a fresh 6-character
+  alphanumeric OTP. Used as the `otp` field of `enroll:request`.
+- `otp:put:<otp>` — owner-authenticated. Stores a semi-permanent OTP
+  for use in headless / CLI enrollment flows.
+- `:ttl:<ms>` — sets the OTP validity window.
+
+**Response**: `data:<otp>` (for `get`) or `data:ok` (for `put`).
+
+#### 9.4.3 The `keys` verb
+
+> **Status: being deprecated.** New implementations should not produce
+> `keys` verbs. The current APKAM enrollment flow still emits them
+> under the covers, but the verb is on the path to removal — it
+> overlaps with `update`/`llookup`/`delete` against the
+> `__pkams` / `__manage` namespaces and adds parsing surface without
+> adding capability. Track the deprecation work alongside the
+> [new AtKeys structure](#c3-new-atkeys-structure) and
+> [pluggable encryption](#c1-post-quantum-cryptography-and-crypto-agility)
+> projects in Appendix C — both intersect with this verb's role.
+
+```
+keys:<put|get|delete>[:public|private|self][:namespace:<ns>][:appName:<n>][:deviceName:<n>][:keyType:<t>][:encryptionKeyName:<n>][:keyName:<n>] [<value>]
+```
+
+Source: see `at_commons/lib/src/verb/syntax.dart`.
+
+`keys` is the storage / retrieval verb for APKAM-issued keys. The
+APKAM enrollment flow uses it under the covers to publish the new
+device's APKAM public key and to retrieve the encrypted bootstrap keys
+on the receiving side. App code rarely calls it directly.
+
+**Response**: `data:-1` on `put` (commit ID; APKAM keys are
+non-committed) and `data:<JSON record>` on `get`.
+
+---
+
+## 10. CRUD verbs
+
+All CRUD verbs require an authenticated connection (owner or APKAM-
+authenticated). The unauthenticated case for `lookup` is handled by
+the dedicated `plookup` verb.
+
+### 10.1 `update`
+
+Insert or overwrite a value, optionally with metadata.
+
+**Syntax (positional form)**
+
+```
+update[:nc]<metadata>[:public|@<forAtSign>]:<atKey>[@<atSign>] <value>
+```
+
+**Syntax (JSON form)**
+
+```
+update[:nc]:json:<json>
+```
+
+Source:
+```
+^update(:nc(?<noCommit>))?(:json:(?<json>.+)|<metadataFragment>(:(public|@(?<forAtSign>...)))?:(?<atKey>...)(@(?<atSign>...))? (?<value>.+))$
+```
+
+`:nc` (no-commit) suppresses the commit-log entry, used for local
+keys that should not be synced.
+
+**Response** — `data:<commitId>` where `commitId` is the integer
+commit-log sequence number assigned to the operation. Self-connected
+clients use this to detect that their local cache is at least as
+fresh as the server.
+
+```
+C: update:@bob:phone.wavi@alice +1 555 0100\n
+S: data:42\n@alice@
+```
+
+Setting metadata at update time:
+
+```
+C: update:ttr:60000:ccd:true:isEncrypted:true:@bob:secret.myapp@alice <ciphertext>\n
+S: data:43\n@alice@
+```
+
+JSON form (atomic put with full metadata):
+
+```
+C: update:json:{"atKey":{"key":"phone","sharedWith":"@bob","sharedBy":"@alice","namespace":"wavi"},"value":"+1 555 0100","metadata":{"ttl":60000}}\n
+S: data:44\n@alice@
+```
+
+### 10.2 `update:meta`
+
+Update only the metadata of an existing key. Same metadata fragment as
+`update`. Useful for changing TTL or marking a key encrypted after
+the fact.
+
+```
+C: update:meta:@bob:phone.wavi@alice:ttl:600000:isEncrypted:true\n
+S: data:45\n@alice@
+```
+
+### 10.3 `delete`
+
+Remove an atKey.
+
+**Syntax**
+
+```
+delete[:dAt:<timestamp>][:nc][:force][:priority:<low|medium|high>][:cached][:public|@<forAtSign>]:<atKey>[@<atSign>]
+```
+
+Source:
+```
+^delete(:dAt:...)?(:nc)?(:force)?(:priority:...)?(:cached)?(:public|@<forAtSign>)?:<atKey>(@<atSign>)?$
+```
+
+- `:dAt:<timestamp>` — assert deletion time (used by sync).
+- `:nc` — no commit.
+- `:force` — required to delete an `immutable:true` key.
+- `:cached` — delete a cached copy on this server (does not affect the
+  origin).
+
+**Response** — `data:<commitId>` (yes, even when the key didn't exist
+— `delete` is idempotent and always commits).
+
+```
+C: delete:@bob:phone.wavi@alice\n
+S: data:46\n@alice@
+```
+
+If `autoNotify` is enabled and the key was a shared key with a
+recipient on a different atServer, the server emits a `notify:delete`
+to the recipient — see [§11](#11-notification-verbs).
+
+### 10.4 `lookup`
+
+Read a value from another atSign's atServer (cross-atSign read,
+authenticated). Internally proxied via the requestor's local atServer
+— see [§15](#15-the-inter-atserver-protocol).
+
+**Syntax**
+
+```
+lookup[:bypassCache:<true|false>][:meta|all]:<atKey>@<atSign>
+```
+
+Source:
+```
+^lookup:(bypassCache:(?<bypassCache>true|false):)?((?<operation>meta|all):)?(?<atKey>(?:[^:]).+)@(?<atSign>[^:@\s]+)$
+```
+
+- Default operation: returns the value only.
+- `meta:` — return metadata only.
+- `all:` — return both value and metadata.
+- `bypassCache:true` — force a fetch from the remote rather than
+  returning a cached copy.
+
+**Response shapes**
+
+Default:
+```
+data:<value>
+```
+
+`meta:`:
+```
+data:{"createdBy":"@bob","updatedBy":"@bob","createdAt":"…","updatedAt":"…","ttl":null,"ttb":null,"ttr":10000,"ccd":false,"isBinary":false,"isEncrypted":true, …}
+```
+
+`all:`:
+```
+data:{"key":"@alice:country.wavi@bob","data":"USA","metaData":{ … }}
+```
+
+If the remote atServer is unreachable: `error:AT0007-atServer not found.`
+
+### 10.5 `plookup`
+
+Public lookup — read a public key from any atSign without
+authentication. The server may answer from its own cache (per the
+key's `ttr`) unless `:bypassCache:true:` is set.
+
+**Syntax**
+
+```
+plookup[:bypassCache:<true|false>][:meta|all]:<atKey>@<atSign>
+```
+
+Same response shape as `lookup`.
+
+### 10.6 `llookup`
+
+Local lookup — read a key from this atServer's own keystore. Returns
+the stored value verbatim (no resolution, no remote fetch).
+
+**Syntax**
+
+```
+llookup[:meta|all][:cached][:public|@<forAtSign>]:<atKey>@<atSign>
+```
+
+Source:
+```
+^llookup(:(?<operation>meta|all))?(:cached)?(:(public|@<forAtSign>))?:<atKey>@<atSign>$
+```
+
+- `:cached:` — look up a cached copy on this atServer.
+
+Response is identical in shape to `lookup`.
+
+### 10.7 `scan`
+
+Enumerate keys.
+
+**Syntax**
+
+```
+scan[:cl][:showhidden:<true|false>][:<forAtSign>][:page:<n>][ <regex>]
+```
+
+Source:
+```
+^scan$|scan(:cl)?(:showhidden:...)?(:<forAtSign>)?(:page:...)?( <regex>)?$
+```
+
+- `:cl` — scan the commit log instead of the keystore.
+- `:showhidden:true` — include keys whose `<key>` starts with `_`.
+- `:<forAtSign>` — only return keys shared with that atSign.
+- `:page:<n>` — pagination index (server-defined page size).
+- `<regex>` (space-separated) — filter results by regex.
+
+**Response**
+
+```
+data:["public:phone.wavi@alice","@bob:email.wavi@alice", …]
+```
+
+A JSON array of strings, on a single line. Empty result is `data:[]`.
+
+The `forAtSign` and `regex` filters operate on key **structure**, not
+value contents — value-level filtering is impossible because the
+server has no plaintext to filter against ([§14](#14-end-to-end-encryption)).
+
+---
+
+## 11. Notification verbs
+
+Notifications are the protocol's pub/sub mechanism. An owner emits a
+notification when shared data changes; the recipient's atServer
+receives it via inter-atServer delivery
+([§15](#15-the-inter-atserver-protocol)) and surfaces it to the
+recipient's atClient via `monitor`.
+
+### 11.1 `notify`
+
+Emit a notification.
+
+**Syntax**
+
+```
+notify[:id:<id>][:<update|delete>][:messageType:key][:priority:<low|medium|high>][:strategy:<all|latest>][:latestN:<n>][:notifier:<n>][:ttln:<ms>]<metadata>:[public|@<forAtSign>]:<atKey>[@<atSign>][:<value>]
+```
+
+Source: see `at_commons/lib/src/verb/syntax.dart` `notify`.
+
+| Tag             | Description                                                                                           |
+| --------------- | ----------------------------------------------------------------------------------------------------- |
+| `id`            | Caller-supplied notification ID. Server generates one if omitted.                                     |
+| `update|delete` | Operation. Defaults to `update`.                                                                      |
+| `messageType:key` | Notification refers to an atKey change. (`text` exists; **deprecated** — see Appendix B.)            |
+| `priority`      | Delivery priority hint.                                                                               |
+| `strategy:all`  | Deliver every notification (default).                                                                 |
+| `strategy:latest` | Coalesce: deliver only the most recent `<latestN>` for the same atKey if recipient was offline.    |
+| `latestN`       | Coalesce window size. Used with `strategy:latest`.                                                    |
+| `notifier`      | Identifier of the notifying subsystem. Defaults to `SYSTEM`.                                          |
+| `ttln`          | Notification time-to-live in ms. After expiry the server gives up delivering and marks `expired`.    |
+
+**Response** — `data:<notificationId>` on success.
+
+```
+C: notify:update:ttr:-1:isEncrypted:true:@bob:phone.wavi@alice <ciphertext>\n
+S: data:7c6c8d7d-7e0e-4ab4-9c7d-4b07e1e84a52\n@alice@
+```
+
+### 11.2 `notify:all`
+
+Emit one notification to multiple recipients in one round-trip. The
+recipients are a comma-separated list (no `@` prefix) where the
+single `forAtSign` segment normally goes.
+
+**Syntax**
+
+```
+notify:all:[<update|delete>:][messageType:<key|text>:][ttl:<ms>:][ttb:<ms>:][ttr:<ms>:][ccd:<bool>:]<recipient,recipient,…>:<atKey>[@<atSign>][:<value>]
+```
+
+**Response** — a JSON map of `recipient → notificationId`:
+
+```
+data:{"@bob":"…uuid…","@colin":"…uuid…"}
+```
+
+### 11.3 `notify:list`
+
+List notifications received by the current atSign.
+
+**Syntax**
+
+```
+notify:list[:<fromDate>][:<toDate>][:<regex>]
+```
+
+Dates are `YYYY-MM-DD`. Source:
+```
+^notify:list(:(?<fromDate>\d{4}-[01]?\d?-[0123]?\d?))?(:(?<toDate>...))?(:(?<regex>[^:]+))?
+```
+
+**Response** — JSON array of notification records:
+
+```
+data:[{"id":"…","from":"@bob","to":"@alice","key":"@alice:phone.wavi@bob","value":null,"operation":"update","epochMillis":1603714720965}, …]
+```
+
+If the connection is `pol`-authenticated, returns notifications **sent
+to** that atSign instead.
+
+### 11.4 `notify:status`
+
+Query the delivery status of a notification by ID.
+
+**Syntax**
+
+```
+notify:status:<notificationId>
+```
+
+**Response** — `data:<status>` where status is one of:
+
+| Status        | Meaning                                                |
+| ------------- | ------------------------------------------------------ |
+| `queued`      | Not yet sent.                                          |
+| `delivered`   | Successfully delivered to the recipient's atServer.    |
+| `undelivered` | Tried and failed; will retry per server policy.        |
+| `errored`     | Delivery errored permanently.                          |
+| `expired`     | TTL elapsed before delivery succeeded.                 |
+
+### 11.5 `notify:fetch`
+
+Fetch a full notification record by ID.
+
+**Syntax**
+
+```
+notify:fetch:<notificationId>
+```
+
+**Response** — `data:<JSON notification record>`. If the notification
+was expired or never existed, returns
+`data:{"id":"<id>","notificationStatus":"expired"}`.
+
+### 11.6 `notify:remove`
+
+Remove a notification from the local notification log. Note: this is
+log housekeeping; it does **not** send a `notify:delete` to the
+recipient.
+
+**Syntax**
+
+```
+notify:remove:<notificationId>
+```
+
+**Response** — `data:success`.
+
+### 11.7 `monitor`
+
+Open a long-lived stream of received notifications.
+
+**Syntax**
+
+```
+monitor[:strict][:selfNotifications][:multiplexed][:<epochMillis>][ <regex>]
+```
+
+Source:
+```
+^monitor(:strict)?(:selfNotifications)?(:multiplexed)?(:<epochMillis>)?( <regex>)?$
+```
+
+| Modifier            | Effect                                                                                              |
+| ------------------- | --------------------------------------------------------------------------------------------------- |
+| `strict`            | Emit **only** notifications matching the regex; suppress server-control notifications (e.g. stats). |
+| `selfNotifications` | Include notifications the connecting atSign emitted itself.                                         |
+| `multiplexed`       | Allow request-response interleaving on the same connection.                                          |
+| `<epochMillis>`     | Replay notifications received at or after this timestamp.                                            |
+| `<regex>`           | Filter notifications by atKey regex.                                                                 |
+
+**Response** — a stream. Each notification arrives as one line:
+
+```
+notification: {"id":"…","from":"@bob","to":"@alice","key":"@alice:phone.wavi@bob",…}
+```
+
+Lines are not framed by the standard `\n@…@` prompt. The connection
+remains open until either side closes it. Server-control
+notifications use the same `notification: …` prefix unless `:strict`
+is set.
+
+If `:multiplexed` is set, the server processes a subsequent verb
+arriving on the same connection (e.g. `lookup`) when no notification
+delivery is mid-flight, and emits the response with the standard
+prompt; notifications resume after the response.
+
+---
+
+## 12. The sync verb
+
+`sync:from` walks the commit log of an atServer from a given commit ID
+to the current head, returning the intervening operations. Used both
+by clients (to keep a local cache fresh) and by atServers (to
+synchronise with their cloud counterpart).
+
+### 12.1 `sync:from`
+
+**Syntax**
+
+```
+sync:from:<from_commit_seq>[:limit:<n>][:skipDeletesUntil:<n>][:<regex>]
+```
+
+Source:
+```
+^sync:from:(?<from_commit_seq>[0-9]+|-1)(:limit:(?<limit>\d+))?(:skipDeletesUntil:(?<skipDeletesUntil>\d+))?(:(?<regex>.+))?$
+```
+
+- `<from_commit_seq>` — last commit ID the caller has seen. `-1`
+  requests the full commit log from the start.
+- `:limit:<n>` — max entries returned in this round-trip. Caller
+  paginates by repeating with the highest commit ID seen.
+- `:skipDeletesUntil:<n>` — suppress delete operations whose
+  `commitId <= n`. Used to elide tombstones older than a known sync
+  high-water mark.
+- `:<regex>` — filter entries by atKey regex.
+
+**Response** — JSON array of commit-log entries:
+
+```
+data:[{"atKey":"@bob:phone.wavi@alice","operation":"+","opTime":"2026-05-05T10:30:00.000Z","commitId":42,"value":"<ciphertext>","metadata":{"ttr":-1,"ccd":false,"isEncrypted":true}},
+      {"atKey":"@bob:shared_key.wavi@alice","operation":"-","opTime":"2026-05-05T10:31:42.000Z","commitId":43}]
+```
+
+Operations: `+` for upsert, `-` for delete, `*` for metadata-only
+update.
+
+The legacy `sync:<from_commit_seq>` syntax (without `:from:`) is
+retained for backward compatibility and is documented in
+[Appendix B](#appendix-b--legacy-and-deprecated). New clients must
+use `sync:from`.
+
+---
+
+## 13. Server-admin and utility verbs
+
+### 13.1 `config`
+
+Manage server-side block lists and configuration parameters. Owner-
+authenticated only.
+
+**Syntax**
+
+```
+config:block:add:@<atSign>[ @<atSign> …]
+config:block:remove:@<atSign>[ @<atSign> …]
+config:block:show
+config:set:<key>=<value>
+config:reset:<key>
+config:print:<key>
+```
+
+The block list, once populated, is consulted by `from` — a blocked
+atSign receives `error:AT0013-Connection Exception` and the connection
+is closed.
+
+**Response** — `data:success` for mutating operations, `data:[…]` for
+`show` (a JSON array of blocked atSigns), `data:<value>` for `print`.
+
+### 13.2 `stats`
+
+Return server statistics.
+
+**Syntax**
+
+```
+stats[:<id>[,<id>…]][:<regex>]
+```
+
+Source:
+```
+^stats(?<statId>:((?!0)\d+)?(,(\d+))*)?(:(?<regex>(?<=:3:|:15:).+))?$
+```
+
+Without IDs, all statistics are returned. Statistics are identified
+by integer IDs:
+
+| ID  | Name                        | Value type                    |
+| --- | --------------------------- | ----------------------------- |
+| 1   | `activeInboundConnections`  | int                           |
+| 2   | `activeOutboundConnections` | int                           |
+| 3   | `lastCommitId`              | int                           |
+| 4   | `secondaryStorageSize`      | int (bytes)                   |
+| 5   | `topAtSigns`                | `{<atSign>: <hits>, …}`       |
+| 6   | `topKeys`                   | `{<atKey>: <hits>, …}`        |
+
+(Servers may expose additional IDs — IDs 11 and 15 take regex filters
+per the syntax; see source for current set.)
+
+**Response**
+
+```
+data:[{"id":"1","name":"activeInboundConnections","value":"1"},
+      {"id":"3","name":"lastCommitId","value":"42"}, …]
+```
+
+### 13.3 `info`
+
+Return server runtime information.
+
+**Syntax**
+
+```
+info[:brief|mtls|mtlsbrief]
+```
+
+**Response shapes**
+
+`info` (full):
+```
+data:{"version":"3.0.28","uptimeAsWords":"1 hours 35 minutes 29 seconds","features":[ {…feature record…}, … ]}
+```
+
+`info:brief`:
+```
+data:{"version":"3.0.28","uptimeAsMillis":5855295}
+```
+
+`info:mtls`:
+```
+data:{"mtls_fullchain":"<PEM>"}
+```
+
+`info:mtlsbrief`:
+```
+data:{"mtls_fullchain_last_modified":"2026-05-05T08:00:00.000Z","mtls_privkey_last_modified":"2026-05-05T08:00:00.000Z"}
+```
+
+`info` may be called unauthenticated; servers may restrict per
+deployment.
+
+### 13.4 `noop`
+
+Sleep for the given number of milliseconds, then respond. Used as a
+keep-alive / latency probe.
+
+**Syntax**
+
+```
+noop:<delayMillis>
+```
+
+`<delayMillis>` ≤ 5000.
+
+**Response** — `data:ok` after the delay. Out-of-range values produce
+`error:AT0022-Exception: noop:<durationInMillis> where the duration
+maximum is 5000 milliseconds`.
+
+### 13.5 `batch`
+
+Execute multiple verbs in a single round-trip. Each member of the
+batch is independently parsed and dispatched; failures are per-entry.
+
+**Syntax**
+
+```
+batch:<json-array>
+```
+
+Where `<json-array>` is `[{"id":<n>,"command":"<verb>"}, …]` and each
+`<verb>` is a single-line verb without the trailing `\n`.
+
+**Response** — array of `{id, response}` pairs in submission order:
+
+```
+data:[{"id":1,"response":{"data":"42"}},{"id":2,"response":{"data":"43"}}]
+```
+
+---
+
+## 14. End-to-end encryption
+
+End-to-end encryption is **entirely an atClient concern**. atServers
+store opaque ciphertext in the `value` field, opaque ciphertext in the
+`sharedKeyEnc` metadata field, and opaque metadata about which keys
+encrypted which — but they never see plaintext keys, plaintext values,
+or have any way to decrypt anything they store. No server-side
+behaviour in this specification depends on understanding what the
+encrypted material means.
+
+This section describes how the wire-level metadata fields hang together
+so an atClient implementer can interoperate with the existing Dart
+SDK. It does **not** specify the encryption protocol normatively; that
+lives in the [`at_chops`](https://pub.dev/packages/at_chops) package
+and is allowed to evolve.
+
+### 14.1 Two layers
+
+Atsign Protocol e2ee uses two layers:
+
+1. **Symmetric layer.** Each atSign holds one symmetric **shared key**
+   per recipient. Values shared from `@alice` to `@bob` are encrypted
+   with `alice`'s sharedKey-for-bob (AES). The metadata fields
+   `encKeyName`, `encAlgo`, `ivNonce`, and `encoding` describe this
+   encryption.
+2. **Asymmetric layer.** The shared key is itself encrypted with the
+   recipient's encryption public key (RSA), serialised into the
+   `sharedKeyEnc` metadata field, and pinned to the public key that
+   wrapped it via `pubKeyHash` (and `hashingAlgo`) and `skeEncKeyName`
+   / `skeEncAlgo`.
+
+Inline shared-key delivery (`sharedKeyEnc` carried in the metadata of
+the value itself) is the supported pattern. Alternative delivery via a
+separately-stored `<atSign>:shared_key.<namespace>@<owner>` atKey is
+accepted for backward compatibility but not recommended.
+
+### 14.2 Public-data signatures
+
+Public values may be signed by the owner's signing private key; the
+signature appears in `dataSignature`. Recipients verify against the
+owner's `public:signing_publickey@<owner>`. This is the only signature
+on a value-side payload — encrypted (shared) values rely on the AES
+authenticated-encryption mode in `encAlgo` to detect tampering.
+
+### 14.3 Public-key rotation
+
+If the recipient rotates their encryption keypair, every shared key
+encrypted to the old public key becomes unrecoverable. `pubKeyHash`
+lets the recipient detect this on read: if the hash doesn't match
+their current public key, the recipient asks the sender to re-share.
+There is no in-protocol re-key flow; the sender simply re-issues the
+update with a fresh `sharedKeyEnc`.
+
+### 14.4 Why server-side filtering is impossible
+
+The atServer holds:
+
+- ciphertext in `value`
+- ciphertext in `sharedKeyEnc`
+- metadata fields whose meaning it cannot interpret without keys it
+  does not have
+
+Any feature requiring the server to reason about plaintext — value-
+level filters, server-side aggregations over content, content-based
+notifications — is therefore architecturally impossible. This is a
+**security property**, not a performance limitation. Filtering by
+atKey **structure** (regex on the wire-form name) is supported and is
+how `scan`, `notify:list` regexes, and `monitor` filters work.
+
+---
+
+## 15. The inter-atServer protocol
+
+When an atClient asks its atServer for cross-atSign data — `lookup`,
+remote `scan`, or sending a `notify` whose recipient is on a different
+atServer — the atServer **proxies** the request. It opens a TLS
+connection to the target atServer (resolved via the atDirectory),
+authenticates via the `pol` handshake, and runs the appropriate verb
+on behalf of the requesting client.
+
+This chapter specifies that proxying. The single most important verb
+here is `pol`, the proof-of-life handshake between two atServers.
+
+### 15.1 Outbound connection lifecycle
+
+Source: `at_secondary_server/lib/src/connection/outbound/outbound_client.dart`.
+
+1. Local atServer (call it **A**) needs to talk to remote atServer
+   **B**. A's `OutboundClientManager` returns an `OutboundClient`
+   for the target atSign — pooled per-target so repeat traffic to the
+   same B reuses one connection.
+2. **Resolve.** A queries its atDirectory for B's host:port.
+3. **Connect.** A opens a TLS connection to B. Most A→B connections
+   are one-way TLS (B presents a cert). For deployments configured
+   with `clientCertificateRequired`, A presents a client cert (mTLS).
+4. **Public-key warm-up.** Before any handshake, A runs an
+   unauthenticated `lookup:all:publickey<B-atSign>` against B and
+   caches the result (cached as
+   `cached:public:publickey@<B-atSign>` in A's keystore). This makes
+   subsequent encryption-to-B operations cheap and detects key
+   rotation early.
+5. **Handshake.** If the planned operation requires authentication, A
+   runs the `pol` handshake — see [§15.2](#152-the-pol-handshake).
+   `lookup` requires it; `plookup` does not.
+6. **Run verbs.** A sends the verb (e.g. `lookup:phone.wavi@alice`),
+   reads the response, strips the trailing prompt, returns the
+   `data:…` payload to the original caller.
+7. **Reuse or close.** The pool keeps the connection open subject to
+   `outbound_idle_time_millis`. On idle expiry the connection is
+   closed.
+
+### 15.2 The `pol` handshake
+
+`pol` ("proof of life") authenticates A to B. It is built on the same
+challenge mechanism as PKAM but inverted: instead of A signing a
+challenge from B and sending the signature inline, A *publishes* its
+signed challenge as a public atKey on its own atServer (under a
+session-scoped name) and tells B to come and look it up. This means
+the secret signing key never leaves A; B verifies by fetching A's
+public signing key from A and verifying the signature.
+
+**Step-by-step.** Source:
+`at_secondary_server/lib/src/verb/handler/pol_verb_handler.dart` and
+`outbound_client.dart::_establishHandShake`.
+
+```
+A ──TLS──► B  (already connected)
+
+A → B:  from:@A
+B → A:  data:proof:<sessionId>@A:<challenge-uuid>\n@
+
+A:  parses cookieParams from response → (sessionId, challenge)
+A:  signedChallenge = base64( sign_RSA_SHA256(challenge, A_signing_priv) )
+A:  store in own keystore: public:<sessionId>@A = signedChallenge   (TTL ~60s)
+
+A → B:  pol\n
+
+B's pol handler:
+  - Verifies A's `from:` already executed on this connection.
+  - Opens its own outbound to A (no handshake required — public lookup):
+      B → A:  lookup:<sessionId>@A
+      A → B:  data:<signedChallenge>
+      B → A:  plookup:signing_publickey@A
+      A → B:  data:<A's RSA signing public key>
+  - Reads its own stored secret: get(public:<sessionId>@A) = challenge
+  - Verifies: RSA_SHA256_verify(A_signing_pub, challenge, signedChallenge)
+  - On success: marks the inbound connection as polAuthenticated,
+                deletes the stored secret, responds:
+
+B → A:  @A@
+       (verb result inside B is `pol:@A@`; the PolResponseHandler
+        strips the `pol:` prefix, leaving just the prompt-shaped
+        confirmation `@A@` on the wire — no separate `data:`
+        framing, no trailing `\n@…@`. A's outbound listener
+        recognises completion by the `@<currentAtSign>@` shape.)
+
+A:  reads handshake result; if it begins with "@A@", marks the
+    outbound connection authenticated.
+```
+
+After `pol` succeeds, A's connection to B is authenticated **as @A**.
+B treats subsequent verbs on this connection as coming from `@A` — for
+example, a `lookup:phone.wavi@A` returns only the keys `@A` is allowed
+to read on B's atServer (`@bob:phone.wavi@A`-shaped, where `@bob` is
+B's atSign).
+
+**Failure modes:**
+
+| Cause                                       | Error                                          |
+| ------------------------------------------- | ---------------------------------------------- |
+| `pol` sent without prior `from`             | `error:AT0013-You must execute a 'from:' command before you may run the pol command` |
+| Signature verification fails                | `error:AT0025-Pol Authentication Failed`       |
+| Cannot connect outbound to verify           | `error:AT0007-atServer not found`              |
+| Any other handshake exception               | `error:AT0008-Handshake failure`               |
+
+### 15.3 Cross-atSign `lookup`
+
+Source: `at_secondary_server/lib/src/verb/handler/lookup_verb_handler.dart`.
+
+When @bob's atClient sends `lookup:phone.wavi@alice` to @bob's
+atServer:
+
+1. @bob's atServer recognises the target atSign is not its own.
+2. It obtains an `OutboundClient` for `@alice` from the manager,
+   running the `pol` handshake if needed.
+3. It sends `lookup:phone.wavi@alice` over the now-authenticated
+   outbound connection.
+4. @alice's atServer evaluates the lookup with the inbound connection
+   marked `polAuthenticated as @bob` — the result is whatever @alice
+   has shared **with @bob** (typically `@bob:phone.wavi@alice`).
+5. @alice's atServer responds `data:<value>\n@bob@` (the
+   pol-authenticated prompt).
+6. @bob's atServer strips the prompt, returns `data:<value>` to
+   @bob's atClient.
+
+The entire round-trip is one atServer-to-atServer connection per
+(target atSign, source atSign) pair, pooled and reused.
+
+### 15.4 Cross-atSign `notify` delivery
+
+When the originator's atServer needs to deliver a notification to a
+recipient on a different atServer, it uses the same
+`OutboundClient.pol → notify` path. The remote `notify` verb on the
+recipient's atServer recognises the inbound connection as
+pol-authenticated and stores the notification in the recipient's
+inbox; the recipient sees it via `monitor`.
+
+### 15.5 Server-to-server `sync:from`
+
+For self-hosted deployments where an atServer pairs with a "cloud"
+mirror (or vice versa), `sync:from` runs over the same
+pol-authenticated outbound connection. Both ends use the same
+commit-log walking protocol described in [§12](#12-the-sync-verb); no
+new verbs are introduced.
+
+---
+
+## 16. Worked flows
+
+### 16.1 CRAM bootstrap (Phase 2 onboarding)
+
+The first time an atClient authenticates as a freshly-registered
+atSign, it has only the CRAM secret. It must (a) authenticate, (b)
+generate keypairs, (c) publish the public halves, (d) write the
+private halves to disk.
+
+```
+C: <TCP+TLS connect to alice's atServer>
+C: from:@alice\n
+S: data:_4af24c03-d732-48f8-a9a2-570e8fb6a01c@alice:d6cac849-9c29-42b0-b0c5-493db62728b9\n@
+
+C: cram:<sha512_hex(cramSecret + "_4af24c03-d732-48f8-a9a2-570e8fb6a01c@alice:d6cac849-9c29-42b0-b0c5-493db62728b9")>\n
+S: data:success\n@alice@
+
+# Generate RSA-2048 PKAM keypair, RSA-2048 encryption keypair, AES-256
+# self-encryption key (all client-side, never on the wire as plaintext).
+
+C: update:privatekey:at_pkam_publickey <PKAM public key>\n
+S: data:0\n@alice@
+
+C: update:public:publickey@alice <encryption public key>\n
+S: data:1\n@alice@
+
+C: update:public:signing_publickey@alice <signing public key>\n
+S: data:2\n@alice@
+
+# Write .atKeys file: PKAM private key + encryption private key +
+# self-encryption key, all encrypted-at-rest with the user's password.
+```
+
+After bootstrap, the CRAM secret is no longer accepted. The same
+client now reconnects with `from` + `pkam` for any subsequent session.
+
+### 16.2 APKAM enrollment end-to-end
+
+Phase 3 — a new app on a new device authenticates as `@alice` without
+ever holding the master keys.
+
+```
+# === New device: generate APKAM keypair, generate APKAM symmetric key,
+#                 RSA-encrypt the APKAM symmetric key to alice's
+#                 public:publickey@alice ===
+
+# === Existing master-keys session: get an OTP for the new device. ===
+C(master): otp:get\n
+S:        data:A1B2C3\n@alice@
+# (Owner reads "A1B2C3" to the new device.)
+
+# === New device: submit enrollment request. ===
+C(new): from:@alice\n
+S:      data:proof:<sessionId>@alice:<chal>\n@
+# (No prior PKAM keys; the new device authenticates the enroll:request
+# verb as unauthenticated — the OTP is the credential here.)
+C(new): enroll:request:{
+          "appName":"todos",
+          "deviceName":"phone-1",
+          "namespaces":{"todos":"rw"},
+          "otp":"A1B2C3",
+          "apkamPublicKey":"<base64 RSA pub>",
+          "encryptedAPKAMSymmetricKey":"<RSA-to-alice's-encryption-pub>"
+        }\n
+S:      data:{"enrollmentId":"<uuid>","status":"pending"}\n@
+
+# === Existing master-keys session: monitor for enrollment notifications. ===
+C(master): monitor\n
+S:         notification: {"id":"…","key":"<uuid>.new.enrollments.__manage@alice", …}
+
+# === Existing master-keys session: fetch and approve. ===
+C(master): enroll:fetch:{"enrollmentId":"<uuid>"}\n
+S:         data:{ <full request including encryptedAPKAMSymmetricKey> }\n@alice@
+
+# Master decrypts encryptedAPKAMSymmetricKey using its
+# default encryption private key. Now both sides share the APKAM
+# symmetric key.
+
+# Master encrypts its OWN default encryption private key + self-encryption
+# key with the APKAM symmetric key (AES, with random IVs).
+
+C(master): enroll:approve:{
+             "enrollmentId":"<uuid>",
+             "encryptedDefaultEncryptionPrivateKey":"<AES ciphertext>",
+             "encPrivateKeyIV":"<base64 IV>",
+             "encryptedDefaultSelfEncryptionKey":"<AES ciphertext>",
+             "selfEncKeyIV":"<base64 IV>"
+           }\n
+S:         data:{"enrollmentId":"<uuid>","status":"approved"}\n@alice@
+
+# === New device: PKAM-authenticate using the APKAM private key + enrollmentId. ===
+C(new): from:@alice\n
+S:      data:proof:<sessionId>@alice:<chal>\n@
+C(new): pkam:enrollmentId:<uuid>:<base64 RSA-SHA256 signature of chal>\n
+S:      data:success\n@alice@
+
+# New device now retrieves its bootstrap material:
+C(new): keys:get:keyName:public:encryption_<uuid>.__public_keys.__pkams@alice\n
+S:      data:{ "enrollmentId":"<uuid>", "value":"<encryptedDefaultEncryptionPrivateKey>", "iv":"…" }\n@alice@
+# (And likewise for the self-encryption key.)
+
+# New device decrypts those using its now-shared APKAM symmetric key,
+# writes them locally as its scoped .atKeys, and is fully provisioned.
+```
+
+The new device never sees the master signing private key. APKAM-issued
+keys are revocable via `enroll:revoke`.
+
+### 16.3 Cross-atSign read with pol handshake
+
+@bob looks up `@alice`'s phone number, which `@alice` has shared with
+him.
+
+```
+# === atClient session as @bob, authenticated to @bob's atServer. ===
+C(bob): lookup:phone.wavi@alice\n
+
+# @bob's atServer proxies (this is invisible to the atClient):
+#
+#   bobServer ──TLS──► aliceServer
+#
+#   bobServer → aliceServer:  from:@bob
+#   aliceServer → bobServer:  data:proof:<sessionId>@bob:<chal>\n@
+#
+#   bobServer signs <chal> with @bob's signing private key.
+#   bobServer stores public:<sessionId>@bob = signedChallenge in its
+#   own keystore.
+#
+#   bobServer → aliceServer:  pol\n
+#
+#   aliceServer:
+#     opens unauthenticated outbound to bobServer
+#     bobServer → aliceServer (in pol):
+#         lookup:<sessionId>@bob → data:<signedChallenge>
+#         plookup:signing_publickey@bob → data:<@bob's signing pub key>
+#     verifies signature; succeeds.
+#
+#   aliceServer → bobServer:  @bob@   (PolResponseHandler strips `pol:`)
+#
+#   bobServer → aliceServer:  lookup:phone.wavi@alice\n
+#   aliceServer → bobServer:  data:<ciphertext>\n@bob@
+#
+#   bobServer strips prompt, returns to atClient:
+
+S(bob): data:<ciphertext>\n@bob@
+```
+
+@bob's atClient decrypts `<ciphertext>` using the AES key in
+`sharedKeyEnc` (which it RSA-decrypts with its own encryption private
+key). The decryption is end-to-end; neither atServer can read the
+phone number.
+
+### 16.4 monitor + notify round-trip
+
+`@bob` listens for live updates from `@alice`; `@alice` notifies him.
+
+```
+# === @bob: open monitor session. ===
+C(bob): monitor\n
+# (no immediate response; stream begins.)
+
+# === @alice: update a shared key and notify. ===
+C(alice): update:ttr:-1:isEncrypted:true:@bob:phone.wavi@alice <ciphertext>\n
+S:        data:42\n@alice@
+C(alice): notify:update:ttr:-1:isEncrypted:true:@bob:phone.wavi@alice <ciphertext>\n
+S:        data:7c6c8d7d-…\n@alice@
+
+# === Inside @alice's atServer:
+#    detects @bob's atServer is remote → opens outbound, runs pol →
+#    forwards `notify:` to @bob's atServer → @bob's atServer stores
+#    the notification → emits to all live monitor connections.
+
+# === @bob's monitor stream: ===
+S(bob): notification: {"id":"7c6c8d7d-…","from":"@alice","to":"@bob","key":"@bob:phone.wavi@alice","value":"<ciphertext>","operation":"update","epochMillis":1714900000000}\n
+```
+
+`@bob`'s atClient decrypts the value as in §16.3.
+
+### 16.5 Sync resumption after reconnect
+
+An atClient that has been offline picks up where it left off.
+
+```
+# Last seen commit ID: 41.
+C: sync:from:41:limit:100\n
+S: data:[
+     {"atKey":"@bob:phone.wavi@alice","operation":"+","commitId":42,"opTime":"…","value":"<ciphertext>","metadata":{"ttr":-1,"isEncrypted":true}},
+     {"atKey":"@bob:email.wavi@alice","operation":"-","commitId":43,"opTime":"…"}
+   ]\n@alice@
+
+# Apply locally; record new high-water mark = 43.
+# If response had reached limit, repeat:
+C: sync:from:43:limit:100\n
+S: data:[]\n@alice@   # fully caught up.
+```
+
+Deletes older than the client's `skipDeletesUntil` threshold can be
+elided to compact long sync windows:
+
+```
+C: sync:from:0:limit:1000:skipDeletesUntil:43\n
+```
+
+---
+
+## 17. Errors
+
+Error responses are framed identically to data responses but with the
+prefix `error:` instead of `data:`:
+
+```
+error:AT0003-Invalid Syntax
+```
+
+(Some errors include a colon-separated detail message instead of a
+hyphen, e.g. `error:AT0025:Authentication Failed`. Implementations
+must accept both forms.)
+
+After certain errors the server closes the connection (notably
+syntax errors and authentication failures). Other errors leave the
+connection open.
+
+### 17.1 Code reference
+
+Sorted by code. The "Class" column gives the Dart exception that
+canonically produces the code; implementations in other languages
+should map to an equivalent.
+
+| Code     | Message                                | Class                              | Connection |
+| -------- | -------------------------------------- | ---------------------------------- | ---------- |
+| `AT0001` | Server exception                       | `AtServerException`                | Closed     |
+| `AT0002` | DataStore exception                    | `DataStoreException`               | Closed     |
+| `AT0003` | Invalid syntax                         | `InvalidSyntaxException`           | Closed     |
+| `AT0004` | Socket error                           | `AtIOException`                    | Closed     |
+| `AT0005` | Buffer limit exceeded                  | `BufferOverFlowException`          | Closed     |
+| `AT0006` | Outbound connection limit exceeded     | `OutboundConnectionLimitException` | Open       |
+| `AT0007` | atServer not found                     | `SecondaryNotFoundException`       | Open       |
+| `AT0008` | Handshake failure                      | `HandShakeException`               | Closed     |
+| `AT0009` | UnAuthorized client in the request     | `UnAuthorizedException`            | Closed     |
+| `AT0010` | Internal server error                  | `InternalServerError`              | Closed     |
+| `AT0011` | Internal server exception              | `InternalServerException`          | Closed     |
+| `AT0012` | Inbound connection limit exceeded      | `InboundConnectionLimitException`  | Closed     |
+| `AT0013` | Connection Exception                   | `BlockedConnectionException`       | Closed     |
+| `AT0014` | Unknown AtClient exception             | `AtClientException`                | n/a (client-only) |
+| `AT0015` | Key not found                          | `KeyNotFoundException`             | Open       |
+| `AT0016` | Invalid key                            | `InvalidAtKeyException`            | Open       |
+| `AT0021` | Unable to connect to atServer          | `SecondaryConnectException`        | n/a (client-only) |
+| `AT0022` | Illegal arguments                      | `IllegalArgumentException`         | Open       |
+| `AT0023` | Timeout waiting for response           | `AtTimeoutException`               | Open       |
+| `AT0024` | Server is paused                       | `ServerIsPausedException`          | Open       |
+| `AT0025` | Authentication failed (cram/pol)       | `UnAuthenticatedException`         | Closed     |
+| `AT0026` | APKAM enrollment pending               | `UnAuthenticatedException`         | Closed     |
+| `AT0027` | APKAM enrollment revoked               | `UnAuthenticatedException`         | Closed     |
+| `AT0028` | Too many requests / throttle exceeded  | `AtThrottleLimitExceeded`          | Open       |
+| `AT0029` | APKAM enrollment expired               | `AtInvalidEnrollmentException`     | Closed     |
+| `AT0031` | Cannot revoke own enrollment           | `AtEnrollmentRevokeException`      | Open       |
+| `AT0032` | Illegal state                          | `IllegalStateException`            | Open       |
+| `AT0401` | Client authentication failed (cram/pkam) | `UnAuthenticatedException`       | Closed     |
+
+### 17.2 Note on `AT0009` vs `AT0401`
+
+`AT0401` is emitted on **authentication** failure (the credential is
+wrong). `AT0009` is emitted on **authorisation** failure (the
+authenticated principal lacks permission for the requested key —
+notably APKAM scopes prohibiting the namespace). Implementations must
+distinguish between them; clients may retry on `AT0401` but not on
+`AT0009`.
+
+---
+
+## 18. Glossary
+
+- **APKAM** — Application PKAM. Per-app, per-device, namespace-scoped
+  authentication built on PKAM. The modern way to authenticate.
+- **atClient** — Software acting on behalf of an atSign owner.
+- **atDirectory** — Service mapping atSign → `host:port` of the
+  atSign's atServer.
+- **atKey** — A key in an atServer's keystore. Five shapes (public,
+  self, shared, local, private) plus augmentations (hidden, cached).
+- **atServer** — The personal server for one atSign.
+- **atSign** — An identifier of the form `@<name>`. Maximum length 55
+  characters.
+- **Commit log** — Append-only log of `update`/`delete` operations.
+  Walked by `sync:from`.
+- **CRAM** — Challenge-Response Authentication Mechanism. The
+  bootstrap-only credential, used during onboarding.
+- **Enrollment** — An APKAM record granting an app a namespace-scoped
+  keypair. Has lifecycle states `pending`, `approved`, `denied`,
+  `revoked`, `expired`.
+- **Master AtKeys** — The atSign's root keypairs (PKAM signing,
+  encryption, self-encryption), produced at onboarding.
+- **OTP** — Six-character alphanumeric one-time password. Used to bind
+  an APKAM enrollment to an out-of-band human approval.
+- **PKAM** — Public-Key Authentication Mechanism. Sign-the-challenge
+  authentication; underpins APKAM.
+- **`pol`** — Proof-of-life. The atServer-to-atServer authentication
+  handshake in which the connecting atServer publishes a signed
+  challenge as a public atKey on its own atServer for the receiving
+  atServer to fetch and verify.
+- **Prompt** — The trailing `\n@…@` (or `\n@`) that frames the next
+  request on a connection.
+- **`sharedKeyEnc`** — Inline-in-metadata, RSA-encrypted shared
+  symmetric key.
+- **Verb** — A single-line command in the protocol.
+
+---
+
+## Appendix A — Verb reference
+
+Terse reference for ctrl-F. Authoritative regex source:
+[`at_commons/lib/src/verb/syntax.dart`](https://github.com/atsign-foundation/at_client_sdk/blob/trunk/packages/at_commons/lib/src/verb/syntax.dart).
+
+| Verb            | Auth | Purpose                                          | Section |
+| --------------- | ---- | ------------------------------------------------ | ------- |
+| `from`          | —    | Identify connecting atSign; receive challenge.   | §9.1    |
+| `cram`          | —    | Bootstrap-only authentication.                    | §9.2    |
+| `pkam`          | —    | Sign-the-challenge authentication.                | §9.3    |
+| `pol`           | —    | Inter-atServer proof-of-life. Server-emitted only.| §15.2   |
+| `enroll`        | varies | APKAM enrollment lifecycle.                      | §9.4.1  |
+| `otp`           | owner | Get/put OTP for APKAM.                            | §9.4.2  |
+| `keys`          | yes  | APKAM-issued key storage. **Being deprecated** — see §9.4.3 and §B.7. | §9.4.3  |
+| `update`        | yes  | Insert/overwrite an atKey.                        | §10.1   |
+| `update:meta`   | yes  | Update only metadata.                             | §10.2   |
+| `delete`        | yes  | Remove an atKey.                                  | §10.3   |
+| `lookup`        | yes  | Cross-atSign read.                                | §10.4   |
+| `plookup`       | —    | Public lookup.                                    | §10.5   |
+| `llookup`       | yes  | Local-server-only lookup.                         | §10.6   |
+| `scan`          | varies | Enumerate atKeys (regex/filter).                  | §10.7   |
+| `notify`        | yes  | Emit a notification.                              | §11.1   |
+| `notify:all`    | yes  | Emit to multiple recipients.                      | §11.2   |
+| `notify:list`   | yes  | List received (or sent, if pol-auth) notifications.| §11.3  |
+| `notify:status` | yes  | Query delivery status.                            | §11.4   |
+| `notify:fetch`  | yes  | Fetch full notification record.                   | §11.5   |
+| `notify:remove` | yes  | Remove from local notification log.               | §11.6   |
+| `monitor`       | yes  | Stream of received notifications.                 | §11.7   |
+| `sync:from`     | yes  | Walk the commit log from an offset.               | §12.1   |
+| `config`        | owner | Block-list and config management.                 | §13.1   |
+| `stats`         | yes  | Server statistics.                                | §13.2   |
+| `info`          | varies | Server runtime info.                              | §13.3   |
+| `noop`          | —    | Sleep then `data:ok`.                             | §13.4   |
+| `batch`         | yes  | Multiple verbs in one round-trip.                 | §13.5   |
+| `@exit`         | —    | atDirectory graceful close.                       | §8.4    |
+
+---
+
+## Appendix B — Legacy and deprecated
+
+The following items remain in the wire grammar for backward
+compatibility but new implementations should not produce them.
+
+### B.1 `cram` as a permanent credential
+
+Pre-onboarding, `cram` is the only credential. Post-onboarding, an
+atServer accepts `cram` only as a fallback for compatibility; modern
+clients use `pkam`/APKAM exclusively. Servers may disable `cram`
+post-onboarding entirely.
+
+### B.2 `sync` (without `:from:`)
+
+```
+sync:<from_commit_seq>[:<regex>]
+```
+
+The pre-`sync:from` syntax. Equivalent to `sync:from:<seq>:<regex>`
+without the `:limit:` and `:skipDeletesUntil:` knobs. New clients use
+`sync:from`.
+
+### B.3 `notify` `messageType:text`
+
+`notify:…:messageType:text:…` is a freeform-text notification (not
+tied to an atKey change). Marked deprecated in `at_commons`. New code
+uses `messageType:key` exclusively; freeform messaging is now done via
+a regular shared atKey + `notify:update`.
+
+### B.4 `pubKeyCS`
+
+Predecessor metadata field to `pubKeyHash`. A truncated checksum
+rather than a full hash; lacks an `algo` companion field. Servers
+accept it on read; new metadata writes must use `pubKeyHash` +
+`hashingAlgo`.
+
+### B.5 `stream`
+
+Binary-framed file transfer between two atSigns. Not used by current
+SDKs; the recommended pattern for sharing binary blobs is `update`
+with `isBinary:true` + `isEncrypted:true`. The `stream` verb's
+implementation is preserved in the atServer but is intentionally not
+specified in this document.
+
+### B.6 `*Commons*` and *atServer/atSecondary* terminology drift
+
+In code you will see the older term **secondary** as a synonym for
+**atServer** (e.g. `at_secondary_server`, `SecondaryNotFoundException`,
+`secondaryAddressFinder`). The two refer to the same thing.
+Documentation and new APIs prefer **atServer**. Implementations should
+emit "atServer not found" in user-facing strings; existing error
+messages with "Secondary Server not found" remain accepted.
+
+### B.7 `keys` verb
+
+The `keys:put|get|delete` verb (§9.4.3) is **being deprecated**. It
+overlaps with `update`/`llookup`/`delete` against the `__pkams` /
+`__manage` namespaces and adds parsing surface without adding
+capability. The current APKAM enrollment flow still uses it under
+the covers; new implementations should not produce it. Removal is
+expected to ride alongside the new AtKeys structure and pluggable
+encryption work in [Appendix C.3](#c3-new-atkeys-structure) /
+[C.1](#c1-post-quantum-cryptography-and-crypto-agility). Servers
+should accept it for the foreseeable future.
+
+---
+
+## Appendix C — Significant near-term projects
+
+This appendix lists active workstreams that will materially change
+parts of this specification. Each entry links to the tracking issue;
+issue threads carry the current design state. Implementers should not
+commit to long-lived choices in these areas without checking the
+tracking issues for the present direction. The list is current as of
+2026-05-05; it is not a roadmap commitment, just a snapshot of what is
+moving.
+
+### C.1 Post-quantum cryptography and crypto agility
+
+The current encryption stack is RSA-2048 (asymmetric) + AES-256
+(symmetric) + SHA-256/SHA-512 (hashing). Transition to post-quantum
+primitives is in active design.
+
+- **Pluggable encryption / decryption schemes** —
+  [at_client_sdk #1891](https://github.com/atsign-foundation/at_client_sdk/issues/1891).
+  Refactor the client encrypt/decrypt path so the algorithm is a
+  pluggable strategy rather than hard-coded RSA + AES. Direction:
+  Signal-style triple-ratchet as the new default. Affects every
+  metadata field that names an algorithm (`encAlgo`, `skeEncAlgo`,
+  `hashingAlgo`).
+- **Implement post-quantum (PQ) cryptography along with crypto
+  agility** —
+  [at_client_sdk #1889](https://github.com/atsign-foundation/at_client_sdk/issues/1889).
+  Land the first PQ primitives behind the pluggable interface above.
+- **Implement post-quantum end-to-end encryption where actors
+  communicate over Atsign Protocol** —
+  [at_client_sdk #1893](https://github.com/atsign-foundation/at_client_sdk/issues/1893).
+  End-to-end PQ encryption on the wire — the protocol-visible part of
+  the PQ work.
+
+Implementers should treat algorithm names in metadata as
+forward-compatible enums and design for new values appearing.
+
+### C.2 Fast sync ("fsync") — Better sync
+
+[at_client_sdk #1894](https://github.com/atsign-foundation/at_client_sdk/issues/1894).
+Replacement for the current commit-log walk-based sync. Targets
+**~10–30 ms end-to-end** (excluding network transit) versus today's
+~50–200 ms. Likely affects:
+
+- The `sync:from` verb's pagination contract or replaces it with a
+  push-based delta channel.
+- The `monitor` connection or a new dedicated channel for delta
+  delivery.
+- Local storage commit semantics on the client side.
+
+The current `sync:from` verb is documented in §12 and remains the
+canonical sync mechanism until fsync ships.
+
+### C.3 New AtKeys structure
+
+[at_client_sdk #1892](https://github.com/atsign-foundation/at_client_sdk/issues/1892).
+Refactor of the on-device `.atKeys` file (and keychain entry) format
+that holds an atSign's private credentials. Not a wire-protocol
+change in itself, but it is paired with the post-quantum work above
+so the file can carry multiple keypairs of differing algorithms. May
+also change which fields appear in `enroll:approve`'s encryption
+envelope.
+
+### C.4 Standardise exception handling across SDK packages
+
+[at_client_sdk #1910](https://github.com/atsign-foundation/at_client_sdk/issues/1910).
+Cleanup of the exception hierarchy, error-code emission, and
+on-the-wire `error:…` shapes. Implementers should expect the error
+catalogue in §17 to gain entries (and possibly normalise the
+hyphen/colon separator inconsistency noted in [§D.1](#d1-error-code-separator-hyphen-vs-colon)).
+
+### C.5 Canonical SDK conformance test suite
+
+[at_client_sdk #1900](https://github.com/atsign-foundation/at_client_sdk/issues/1900).
+A canonical test suite for SDKs in any language to implement. When
+this lands it becomes the de-facto compliance gate for an
+"Atsign-Protocol-compliant" implementation; clients of this
+specification should adopt it.
+
+Related: **at_commons tests reflecting at_server / NoPorts usage** —
+[at_client_sdk #1782](https://github.com/atsign-foundation/at_client_sdk/issues/1782).
+
+### C.6 Move and improve `at_server_spec` into `at_client_sdk/at_commons`
+
+[at_server #2608](https://github.com/atsign-foundation/at_server/issues/2608).
+The `at_server_spec` package (interface definitions used by both the
+server and the client) is being relocated into `at_commons`. This
+specification cites paths in `at_commons/lib/src/verb/syntax.dart`
+that will remain stable, but related interface paths under
+`at_server_spec` should be expected to move.
+
+### C.7 Multi-language SDKs (Java APKAM, others)
+
+- **Java SDK APKAM support** —
+  [operations #348](https://github.com/atsign-foundation/operations/issues/348).
+  The Java SDK is gaining APKAM support, bringing it to parity with
+  the Dart SDK on Phase-3 authentication.
+- **Multi-language support** —
+  [at_client_sdk #1885](https://github.com/atsign-foundation/at_client_sdk/issues/1885).
+  Tracking parent for ports of the SDK to additional languages. This
+  specification document is the basis for those ports.
+
+### C.8 `monitor` immediate-ack response
+
+[at_server #2542](https://github.com/atsign-foundation/at_server/issues/2542).
+Extends the `monitor` verb (§11.7) with an option to request an
+immediate acknowledgement (a prompt) before the notification stream
+begins, so a client can deterministically distinguish "monitor
+established" from "no notifications yet". This will be a backward-
+compatible additive parameter.
+
+### C.9 `at_activate` approval via OTP
+
+[at_client_sdk #1862](https://github.com/atsign-foundation/at_client_sdk/issues/1862).
+Streamlines the Phase-2 onboarding path so that activation can be
+approved via an OTP flow analogous to APKAM's. Not a wire-protocol
+change in itself but tightens the relationship between the `cram`
+bootstrap path (§9.2) and the `otp` verb (§9.4.2).
+
+### C.10 Fork the `encrypt` and `crypton` packages
+
+[operations #385](https://github.com/atsign-foundation/operations/issues/385).
+Atsign-controlled forks of the upstream Dart `encrypt` and `crypton`
+packages, motivated by the post-quantum work and supply-chain
+audit concerns. Affects which crypto primitives are reachable from
+the SDK; not a wire-protocol change.
+
+### C.11 Expired-key lookup returns null
+
+[at_server #2568](https://github.com/atsign-foundation/at_server/issues/2568).
+Today, looking up a key whose `eAt` has passed returns `data:null`;
+the proposed correction is `error:AT0015-Key not found`. A small
+change but observable on the wire — see [§D.4](#d4-expired-keys-return-null-instead-of-an-at0015-error).
+
+---
+
+## Appendix D — Inconsistencies and quirks
+
+This appendix documents on-the-wire surprises that the per-verb
+sections don't make obvious. Implementers writing a parser, a server,
+or an interoperable client need this list. None of these are
+specification bugs in this document — they are facts about the
+deployed protocol that this document accurately describes; they are
+collected here so an implementer can sanity-check failure modes
+against them.
+
+### D.1 Error-code separator: hyphen vs colon
+
+Both forms appear in current servers:
+
+```
+error:AT0003-Invalid Syntax
+error:AT0025:Authentication Failed
+```
+
+The hyphen form predates the colon form; newer error sites tend to
+use `:`. Clients must accept both — splitting only on `-` will fail
+on `AT0025`-class errors, splitting only on `:` will misparse
+hyphen-separated messages.
+
+The base response handler (`base_response_handler.dart` line 35)
+emits `error:<code>:<message>`, but many call sites construct the
+final string with a hyphen instead.
+[Standardise exception handling](#c4-standardise-exception-handling-across-sdk-packages)
+will normalise this.
+
+### D.2 "Secondary Server" vs "atServer" in error messages
+
+Several error messages still use the old "Secondary Server"
+terminology — e.g. `error:AT0007-Secondary Server not found.` Some
+sites have been updated to "atServer not found"; both wordings are
+emitted in different code paths. Same code (`AT0007`), different
+text. Match on the code, not the message.
+
+See also [Appendix B.6](#b6-commons-and-atserveratsecondary-terminology-drift).
+
+### D.3 Per-verb response framing differs
+
+Most verbs follow `data:<payload>\n@<atSign>@` (or `\n@`
+unauthenticated). A handful do not:
+
+- **`pol`** — emits just `@<atSign>@` with no `data:` prefix and no
+  trailing `\n@…@` framing. The `PolResponseHandler` strips the
+  `pol:` prefix from the verb's internal result. Outbound clients
+  detect "pol succeeded" by matching the wire shape `<currentAtSign>@`.
+- **`monitor`** — emits a stream of `notification: {<json>}\n` lines
+  with no per-line `data:` prefix and no trailing prompt between
+  events. Connection remains open until either side closes.
+- **`stream`** — uses binary framing with `stream:ack` / `stream:done`
+  control lines interleaved with raw payload bytes. (`stream` is
+  legacy, see Appendix B.5.)
+- **`from`** — see [§D.6](#d6-from-response-shape-self-vs-cross).
+
+### D.4 Expired keys return null instead of an AT0015 error
+
+A `lookup` against an expired key returns `data:null` rather than
+`error:AT0015-Key not found`. This conflicts with the documented
+behaviour of `KeyNotFoundException` and surprises clients that switch
+on the error path. Tracked in
+[at_server #2568](https://github.com/atsign-foundation/at_server/issues/2568)
+— the proposed fix is to emit `AT0015` consistently. Until then,
+clients reading possibly-expired keys must handle `data:null` as a
+not-found indicator.
+
+### D.5 `notify:list` semantics flip on auth mode
+
+`notify:list` returns:
+
+- the **received** notifications when the connection is authenticated
+  as the server's own atSign (owner)
+- the **sent** notifications when the connection is `pol`-
+  authenticated (i.e. cross-atSign caller asking the recipient's
+  server for what it has on record)
+
+Same verb, same arguments, completely different result set. This is
+intentional but undocumented at the call site; clients may be
+surprised when they switch authentication contexts.
+
+### D.6 `from` response shape: self vs cross
+
+For a self-connect, the `from` response payload is
+
+```
+data:<sessionId><atSign>:<proof>
+```
+
+For a cross-atSign connect, it is
+
+```
+data:proof:<sessionId>@<atSign>:<proof>
+```
+
+The `proof:` infix is the difference. The `FromResponseHandler`
+prepends `data:` only when the verb result starts with `proof:` — the
+self-connect handler emits a string already prefixed `data:`, so
+there is no double-prefixing. Parsers must not assume a uniform
+"`data:` then payload" shape for `from`.
+
+### D.7 `keys:put` returns `data:-1`
+
+`keys:put` is used for APKAM-issued keys, which by design are not
+written to the commit log. Rather than return a real commit ID, the
+handler returns the sentinel `-1`. Clients must not interpret this
+as an error.
+
+### D.8 Mutating verbs typically require auth — `enroll:request` does not
+
+`enroll:request` is a mutating verb (it creates a pending enrollment
+record on the server) but it can be sent on an **unauthenticated**
+connection. The OTP carried in the request is the auth surrogate.
+Every other write verb (`update`, `update:meta`, `delete`, `notify`,
+`keys`) requires an authenticated connection.
+
+### D.9 Newline escaping is value-class-specific
+
+`~NL~` is the on-wire escape for a literal `\n` inside a value, but
+it is applied **only to plaintext public values** by the atServer.
+
+- Encrypted values (`isEncrypted:true`) carry ciphertext that has
+  been base64-encoded; base64 contains no newlines, so the escape is
+  irrelevant.
+- Binary values (`isBinary:true`) are likewise base64-encoded.
+- Self / shared plaintext values are atypical (clients almost always
+  encrypt) and the escape behaviour for them is implementation-
+  specific; do not rely on either path.
+
+Because `\n` is the framing terminator, a client must never write a
+plaintext value containing an unescaped `\n` — the server will treat
+the `\n` as end-of-command.
+
+### D.10 atDirectory historically emits `\r\n@`
+
+Some atDirectory implementations emit `\r\n@` instead of `\n@` after
+their lookup response. Implementations should accept both. atServers
+emit only `\n@`.
+
+### D.11 Metadata fragment is order-sensitive
+
+The `metadataFragment` regex in `at_commons/lib/src/verb/syntax.dart`
+is a sequence of `(:tag:value)?` groups in a fixed order. A request
+that emits `:isEncrypted:true:ttr:-1:` (out of order) does **not**
+match the regex and produces `error:AT0003-Invalid Syntax`. Clients
+must emit metadata tags in the canonical order (the order they
+appear in the regex; reproduced in §7.2).
+
+### D.12 `clientConfig` JSON is unenforced free-form
+
+The `from` verb's `:clientConfig:<json>` segment is parsed by
+`jsonDecode` and a small set of fields (`version`, `clientId`,
+`appName`, `appVersion`, `platform`) is read into the connection's
+metadata. Every other field is silently discarded. There is no
+schema enforcement: malformed-but-parseable JSON is accepted; an
+unrecognised key produces no warning.
+
+### D.13 `delete` is idempotent and always commits
+
+Calling `delete` on a non-existent key returns `data:<commitId>`
+exactly as if the key had existed. The commit log gains a tombstone
+entry regardless. Other CRUD verbs error on a missing target; only
+`delete` is idempotent in this way.
+
+### D.14 Negative metadata integers are mostly meaningless
+
+The metadata regex permits `(-?)\d+` for `ttl`, `ttb`, `ttr`. Only
+`ttr:-1` ("cache forever") is a useful negative; `ttl:-1` and
+`ttb:-1` are accepted by the regex and produce undefined / silently
+useless behaviour. Clients should emit `0` (or omit the tag entirely)
+for "no TTL".
+
+### D.15 `info` auth requirement is per-deployment
+
+The `info` verb's authentication requirement is a server-side config
+toggle, not a fixed property of the protocol. Some deployments
+accept `info` from anonymous connections; others require an
+authenticated session. Implementations should attempt unauthenticated
+first and fall back if rejected.
+
+### D.16 Two metadata tags for the same concept: `pubKeyCS` and `pubKeyHash`
+
+`pubKeyCS` (a checksum) was the predecessor of `pubKeyHash` (a hash
+plus `hashingAlgo` companion field). Servers accept both on read.
+New writes must emit `pubKeyHash` + `hashingAlgo`. A record may
+carry one or the other, never both meaningfully — see Appendix B.4.
+
+### D.17 Session ID format
+
+Session IDs (`<sessionID>` in `from`/`pol`) are produced server-side
+and have a leading `_` followed by a UUID, e.g.
+`_4af24c03-d732-48f8-a9a2-570e8fb6a01c`. The leading underscore
+matters: it makes the per-session keystore entries (`public:<sessionID><atSign>`)
+"hidden" by atKey-shape rules and so they don't appear in `scan`
+output without `:showhidden:true`.

--- a/specification/atsign_protocol_specification.md
+++ b/specification/atsign_protocol_specification.md
@@ -81,8 +81,8 @@ architecturally impossible, see [§14](#14-end-to-end-encryption).
 
 ### For implementers, read these first
 
-Two appendices are load-bearing for anyone implementing this
-specification:
+If you're implementing this specification, read these two appendices
+first:
 
 - [Appendix C, Significant near-term projects](#appendix-c-significant-near-term-projects)
   enumerates active workstreams that will change parts of this

--- a/specification/atsign_protocol_specification.md
+++ b/specification/atsign_protocol_specification.md
@@ -80,18 +80,24 @@ architecturally impossible — see [§14](#14-end-to-end-encryption).
 Two appendices are load-bearing for anyone implementing this
 specification:
 
-- **[Appendix C — Significant near-term projects](#appendix-c--significant-near-term-projects)**
-  enumerates active workstreams that will change parts of this
-  specification within the next few releases (post-quantum
-  cryptography, fast-sync / "fsync", new atKeys structure, pluggable
-  encryption, canonical conformance test suite, etc.). Read this
-  before committing to a long-lived implementation choice.
-- **[Appendix D — Inconsistencies and quirks](#appendix-d--inconsistencies-and-quirks)**
-  enumerates the places where the wire reality is surprising — error
-  separators that aren't uniform, response shapes that differ
-  per-verb, semantics that flip on auth state, and similar gotchas.
-  Read this if your implementation is failing in ways that the
-  per-verb sections don't seem to predict.
+-
+    *
+*[Appendix C — Significant near-term projects](#appendix-c--significant-near-term-projects)
+**
+enumerates active workstreams that will change parts of this
+specification within the next few releases (post-quantum
+cryptography, fast-sync / "fsync", new atKeys structure, pluggable
+encryption, canonical conformance test suite, etc.). Read this
+before committing to a long-lived implementation choice.
+-
+    *
+*[Appendix D — Inconsistencies and quirks](#appendix-d--inconsistencies-and-quirks)
+**
+enumerates the places where the wire reality is surprising — error
+separators that aren't uniform, response shapes that differ
+per-verb, semantics that flip on auth state, and similar gotchas.
+Read this if your implementation is failing in ways that the
+per-verb sections don't seem to predict.
 
 ### Spelling and capitalisation
 
@@ -208,11 +214,11 @@ both.
 A server response is followed by a **prompt** that frames the next
 client request. The prompt is one of:
 
-| Connection state                          | Prompt           |
-| ----------------------------------------- | ---------------- |
-| Unauthenticated                           | `@`              |
-| Authenticated as the server's own atSign  | `@<atSign>@`     |
-| `pol`-authenticated as another atSign     | `<fromAtSign>@`  |
+| Connection state                         | Prompt          |
+|------------------------------------------|-----------------|
+| Unauthenticated                          | `@`             |
+| Authenticated as the server's own atSign | `@<atSign>@`    |
+| `pol`-authenticated as another atSign    | `<fromAtSign>@` |
 
 The prompt is appended to the response line preceded by `\n`. Clients
 detect "response complete" by scanning for the byte sequence `\n@`.
@@ -313,13 +319,13 @@ shapes plus two augmentations.
 
 ### 6.1 The five shapes
 
-| Shape       | Wire format                              | Visibility                                                  |
-| ----------- | ---------------------------------------- | ----------------------------------------------------------- |
-| Public      | `public:<key>[.<namespace>]@<owner>`     | Any atSign (no auth needed via `plookup`)                   |
-| Self        | `<key>[.<namespace>]@<owner>`            | Owner only                                                  |
-| Shared      | `@<recipient>:<key>[.<namespace>]@<owner>` | Owner and `<recipient>` only                              |
-| Local       | `local:<key>[.<namespace>]@<owner>`      | Owner only; **never synced** to a remote atServer           |
-| Private     | `privatekey:<key>[.<namespace>]@<owner>` | Owner only; not enumerated by `scan` (system keys)         |
+| Shape   | Wire format                                | Visibility                                         |
+|---------|--------------------------------------------|----------------------------------------------------|
+| Public  | `public:<key>[.<namespace>]@<owner>`       | Any atSign (no auth needed via `plookup`)          |
+| Self    | `<key>[.<namespace>]@<owner>`              | Owner only                                         |
+| Shared  | `@<recipient>:<key>[.<namespace>]@<owner>` | Owner and `<recipient>` only                       |
+| Local   | `local:<key>[.<namespace>]@<owner>`        | Owner only; **never synced** to a remote atServer  |
+| Private | `privatekey:<key>[.<namespace>]@<owner>`   | Owner only; not enumerated by `scan` (system keys) |
 
 ### 6.2 Augmentations
 
@@ -357,7 +363,7 @@ Every atServer carries a set of system keys created during onboarding.
 These are required for the protocol to function and have stable names:
 
 | Reserved key                        | Purpose                                                                 |
-| ----------------------------------- | ----------------------------------------------------------------------- |
+|-------------------------------------|-------------------------------------------------------------------------|
 | `public:publickey@<atSign>`         | Encryption public key. Used by other atSigns to encrypt to this owner.  |
 | `public:signing_publickey@<atSign>` | PKAM/pol signing public key. Used to verify pol challenges.             |
 | `privatekey:at_pkam_publickey`      | PKAM authentication public key (single-key model; legacy).              |
@@ -373,17 +379,17 @@ namespaces.
 
 ### 6.6 atKey parsing examples
 
-| Wire form                                  | Shape  | Hidden? | Cached? |
-| ------------------------------------------ | ------ | ------- | ------- |
-| `public:phone.wavi@alice`                  | Public | No      | No      |
-| `public:_diagnostics@alice`                | Public | Yes     | No      |
-| `phone.wavi@alice`                         | Self   | No      | No      |
-| `@bob:phone.wavi@alice`                    | Shared | No      | No      |
-| `@bob:_handshake.wavi@alice`               | Shared | Yes     | No      |
-| `cached:public:publickey@alice`            | Public | No      | Yes     |
-| `cached:@bob:phone.wavi@alice`             | Shared | No      | Yes     |
-| `local:cache.myapp@alice`                  | Local  | No      | No      |
-| `privatekey:at_pkam_publickey`             | Private | —      | —       |
+| Wire form                       | Shape   | Hidden? | Cached? |
+|---------------------------------|---------|---------|---------|
+| `public:phone.wavi@alice`       | Public  | No      | No      |
+| `public:_diagnostics@alice`     | Public  | Yes     | No      |
+| `phone.wavi@alice`              | Self    | No      | No      |
+| `@bob:phone.wavi@alice`         | Shared  | No      | No      |
+| `@bob:_handshake.wavi@alice`    | Shared  | Yes     | No      |
+| `cached:public:publickey@alice` | Public  | No      | Yes     |
+| `cached:@bob:phone.wavi@alice`  | Shared  | No      | Yes     |
+| `local:cache.myapp@alice`       | Local   | No      | No      |
+| `privatekey:at_pkam_publickey`  | Private | —       | —       |
 
 ---
 
@@ -400,31 +406,31 @@ should not send tags they don't understand).
 Source of truth: `at_commons/lib/src/verb/syntax.dart`'s
 `metadataFragment`.
 
-| Wire tag           | Type        | Description                                                                                              |
-| ------------------ | ----------- | -------------------------------------------------------------------------------------------------------- |
-| `ttl`              | int (ms)    | Time-to-live. Key auto-deletes `ttl` ms after creation. `0` or omitted = never expires.                 |
-| `ttb`              | int (ms)    | Time-to-birth. Key is invisible to lookups for `ttb` ms after creation.                                  |
-| `ttr`              | int (ms)    | Time-to-refresh for cached copies. `-1` = cache forever; positive = re-fetch interval.                   |
-| `ccd`              | bool        | Cascade-delete. If `true`, deleting the original key deletes its cached copies.                          |
-| `cAt`              | ISO 8601    | `createdAt` — UTC timestamp of creation. Regex: `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z` (fractional seconds optional). |
-| `uAt`              | ISO 8601    | `updatedAt` — UTC timestamp of most recent update.                                                       |
-| `eAt`              | ISO 8601    | `expiresAt` — derived from `cAt + ttl`. Normally server-emitted; clients can also set explicitly (e.g. on sync replay). |
-| `aAt`              | ISO 8601    | `availableAt` — derived from `cAt + ttb`. Same write semantics as `eAt`.                                  |
-| `dataSignature`    | string      | Signature over a public value, signed by the owner's signing private key. Verifies authenticity.        |
-| `sharedKeyStatus`  | enum        | Lifecycle status of a shared key: `localUpdated`, `remoteUpdated`, `sharedWithNotified`, etc.            |
-| `isBinary`         | bool        | `true` if the value is binary (base64-encoded on the wire).                                             |
-| `isEncrypted`      | bool        | `true` if the value is ciphertext.                                                                       |
-| `sharedKeyEnc`     | string      | The shared symmetric key, RSA-encrypted to the recipient's encryption public key. Inline in metadata.   |
-| `pubKeyHash`       | string      | Hash of the recipient public key that encrypted `sharedKeyEnc`. Lets the recipient detect key rotation. |
-| `pubKeyCS`         | string      | **Deprecated.** Predecessor to `pubKeyHash`. New code must emit `pubKeyHash` + `hashingAlgo`.            |
-| `hashingAlgo`      | enum        | Algorithm for `pubKeyHash`: `sha256` or `sha512`.                                                       |
-| `encoding`         | string      | Encoding of the value if not raw UTF-8 (e.g. `base64`).                                                 |
-| `encKeyName`       | string      | Name of the symmetric key used to encrypt the value (resolves to a key name in the owner's keystore).   |
-| `encAlgo`          | string      | Symmetric algorithm used to encrypt the value (e.g. `AES/SIC/PKCS7Padding`).                            |
-| `ivNonce`          | string      | Base64 IV / nonce used in symmetric encryption of the value.                                            |
-| `skeEncKeyName`    | string      | Name of the public key that wrapped `sharedKeyEnc`.                                                      |
-| `skeEncAlgo`       | string      | Algorithm used to wrap `sharedKeyEnc` (default `RSA`).                                                  |
-| `immutable`        | bool        | If `true`, the key cannot be updated; deletion requires `:force:`.                                      |
+| Wire tag          | Type     | Description                                                                                                                     |
+|-------------------|----------|---------------------------------------------------------------------------------------------------------------------------------|
+| `ttl`             | int (ms) | Time-to-live. Key auto-deletes `ttl` ms after creation. `0` or omitted = never expires.                                         |
+| `ttb`             | int (ms) | Time-to-birth. Key is invisible to lookups for `ttb` ms after creation.                                                         |
+| `ttr`             | int (ms) | Time-to-refresh for cached copies. `-1` = cache forever; positive = re-fetch interval.                                          |
+| `ccd`             | bool     | Cascade-delete. If `true`, deleting the original key deletes its cached copies.                                                 |
+| `cAt`             | ISO 8601 | `createdAt` — UTC timestamp of creation. Regex: `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z` (fractional seconds optional). |
+| `uAt`             | ISO 8601 | `updatedAt` — UTC timestamp of most recent update.                                                                              |
+| `eAt`             | ISO 8601 | `expiresAt` — derived from `cAt + ttl`. Normally server-emitted; clients can also set explicitly (e.g. on sync replay).         |
+| `aAt`             | ISO 8601 | `availableAt` — derived from `cAt + ttb`. Same write semantics as `eAt`.                                                        |
+| `dataSignature`   | string   | Signature over a public value, signed by the owner's signing private key. Verifies authenticity.                                |
+| `sharedKeyStatus` | enum     | Lifecycle status of a shared key: `localUpdated`, `remoteUpdated`, `sharedWithNotified`, etc.                                   |
+| `isBinary`        | bool     | `true` if the value is binary (base64-encoded on the wire).                                                                     |
+| `isEncrypted`     | bool     | `true` if the value is ciphertext.                                                                                              |
+| `sharedKeyEnc`    | string   | The shared symmetric key, RSA-encrypted to the recipient's encryption public key. Inline in metadata.                           |
+| `pubKeyHash`      | string   | Hash of the recipient public key that encrypted `sharedKeyEnc`. Lets the recipient detect key rotation.                         |
+| `pubKeyCS`        | string   | **Deprecated.** Predecessor to `pubKeyHash`. New code must emit `pubKeyHash` + `hashingAlgo`.                                   |
+| `hashingAlgo`     | enum     | Algorithm for `pubKeyHash`: `sha256` or `sha512`.                                                                               |
+| `encoding`        | string   | Encoding of the value if not raw UTF-8 (e.g. `base64`).                                                                         |
+| `encKeyName`      | string   | Name of the symmetric key used to encrypt the value (resolves to a key name in the owner's keystore).                           |
+| `encAlgo`         | string   | Symmetric algorithm used to encrypt the value (e.g. `AES/SIC/PKCS7Padding`).                                                    |
+| `ivNonce`         | string   | Base64 IV / nonce used in symmetric encryption of the value.                                                                    |
+| `skeEncKeyName`   | string   | Name of the public key that wrapped `sharedKeyEnc`.                                                                             |
+| `skeEncAlgo`      | string   | Algorithm used to wrap `sharedKeyEnc` (default `RSA`).                                                                          |
+| `immutable`       | bool     | If `true`, the key cannot be updated; deletion requires `:force:`.                                                              |
 
 Negative integer values for `ttl`/`ttb` are accepted by the regex (the
 syntax allows `(-?)\d+`) but server-side semantics are documented at
@@ -514,6 +520,7 @@ from:<atSign>[:clientConfig:<clientConfig-json>]
 ```
 
 Source: `at_commons/lib/src/verb/syntax.dart`:
+
 ```
 ^from:(?<atSign>@?[^:@\s]+)(:clientConfig:(?<clientConfig>\{.+\}))?$
 ```
@@ -522,13 +529,13 @@ The `clientConfig` JSON is optional and free-form. The atServer reads
 the following recognised fields and stores them on the connection
 metadata:
 
-| Field        | Purpose                                                    |
-| ------------ | ---------------------------------------------------------- |
-| `version`    | Client SDK version string                                  |
-| `clientId`   | Unique client / device identifier                          |
-| `appName`    | Application name                                           |
-| `appVersion` | Application version                                        |
-| `platform`   | OS or platform tag (e.g. `iOS`, `Android`, `linux`)        |
+| Field        | Purpose                                             |
+|--------------|-----------------------------------------------------|
+| `version`    | Client SDK version string                           |
+| `clientId`   | Unique client / device identifier                   |
+| `appName`    | Application name                                    |
+| `appVersion` | Application version                                 |
+| `platform`   | OS or platform tag (e.g. `iOS`, `Android`, `linux`) |
 
 Unrecognised fields are ignored.
 
@@ -573,6 +580,7 @@ cram:<digest>
 ```
 
 Source:
+
 ```
 ^cram:(?<digest>.+$)
 ```
@@ -609,6 +617,7 @@ pkam:[signingAlgo:<rsa2048|ecc_secp256r1>:][hashingAlgo:<sha256|sha512>:][enroll
 ```
 
 Source:
+
 ```
 ^pkam:(signingAlgo:(?<signingAlgo>ecc_secp256r1|rsa2048):)?(hashingAlgo:(?<hashingAlgo>sha256|sha512):)?(enrollmentId:(?<enrollmentId>.+):)?(?<signature>.+$)
 ```
@@ -660,6 +669,7 @@ enroll:<operation>[:force][:<enrollParams-json>]
 ```
 
 Source:
+
 ```
 ^enroll:(?<operation>(?:(request|approve|deny|revoke|list|fetch|unrevoke|delete)))(:(?<force>force))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$
 ```
@@ -667,34 +677,34 @@ Source:
 `<enrollParams>` is the JSON serialisation of the `EnrollParams` shape
 (`at_commons/lib/src/verb/enroll_params.dart`):
 
-| Field                                  | Used by         | Description                                                                                  |
-| -------------------------------------- | --------------- | -------------------------------------------------------------------------------------------- |
-| `enrollmentId`                         | approve/deny/revoke/fetch/delete/unrevoke | UUID of the enrollment.                                                  |
-| `appName`                              | request         | Application name, e.g. `"todos"`.                                                           |
-| `deviceName`                           | request         | Unique device identifier.                                                                    |
-| `namespaces`                           | request         | Map of `namespace → permission` (`r`, `w`, `rw`, `rwx`).                                    |
-| `otp`                                  | request         | One-time password from `otp:get`.                                                            |
-| `apkamPublicKey`                       | request         | New device's APKAM public key (PEM or base64).                                              |
-| `encryptedAPKAMSymmetricKey`           | request         | New device's APKAM symmetric key, RSA-encrypted to the default encryption public key.       |
-| `encryptedDefaultEncryptionPrivateKey` | approve         | Owner's encryption private key, AES-encrypted with the APKAM symmetric key.                 |
-| `encPrivateKeyIV`                      | approve         | IV (base64) for the line above.                                                              |
-| `encryptedDefaultSelfEncryptionKey`    | approve         | Owner's self-encryption key, AES-encrypted with the APKAM symmetric key.                    |
-| `selfEncKeyIV`                         | approve         | IV (base64) for the line above.                                                              |
-| `enrollmentStatusFilter`               | list            | Optional list of statuses to filter on: `pending`, `approved`, `denied`, `revoked`, `expired`. |
-| `apkamKeysExpiryDuration`              | request         | ISO-8601 duration: lifetime of the APKAM credentials before forced re-enrollment.            |
+| Field                                  | Used by                                   | Description                                                                                    |
+|----------------------------------------|-------------------------------------------|------------------------------------------------------------------------------------------------|
+| `enrollmentId`                         | approve/deny/revoke/fetch/delete/unrevoke | UUID of the enrollment.                                                                        |
+| `appName`                              | request                                   | Application name, e.g. `"todos"`.                                                              |
+| `deviceName`                           | request                                   | Unique device identifier.                                                                      |
+| `namespaces`                           | request                                   | Map of `namespace → permission` (`r`, `w`, `rw`, `rwx`).                                       |
+| `otp`                                  | request                                   | One-time password from `otp:get`.                                                              |
+| `apkamPublicKey`                       | request                                   | New device's APKAM public key (PEM or base64).                                                 |
+| `encryptedAPKAMSymmetricKey`           | request                                   | New device's APKAM symmetric key, RSA-encrypted to the default encryption public key.          |
+| `encryptedDefaultEncryptionPrivateKey` | approve                                   | Owner's encryption private key, AES-encrypted with the APKAM symmetric key.                    |
+| `encPrivateKeyIV`                      | approve                                   | IV (base64) for the line above.                                                                |
+| `encryptedDefaultSelfEncryptionKey`    | approve                                   | Owner's self-encryption key, AES-encrypted with the APKAM symmetric key.                       |
+| `selfEncKeyIV`                         | approve                                   | IV (base64) for the line above.                                                                |
+| `enrollmentStatusFilter`               | list                                      | Optional list of statuses to filter on: `pending`, `approved`, `denied`, `revoked`, `expired`. |
+| `apkamKeysExpiryDuration`              | request                                   | ISO-8601 duration: lifetime of the APKAM credentials before forced re-enrollment.              |
 
 **Operations and responses**
 
-| Operation   | Response payload                                                       |
-| ----------- | ---------------------------------------------------------------------- |
-| `request`   | `data:{"enrollmentId":"<uuid>","status":"pending"}`                    |
-| `approve`   | `data:{"enrollmentId":"<uuid>","status":"approved"}`                   |
-| `deny`      | `data:{"enrollmentId":"<uuid>","status":"denied"}`                     |
-| `revoke`    | `data:{"enrollmentId":"<uuid>","status":"revoked"}` (`:force:` to revoke own enrollment) |
-| `unrevoke`  | `data:{"enrollmentId":"<uuid>","status":"approved"}`                   |
-| `delete`    | `data:{"enrollmentId":"<uuid>","status":"deleted"}`                    |
-| `fetch`     | `data:{ <full enrollment record JSON> }`                               |
-| `list`      | `data:{"<enrollKey>":{<enrollment record JSON>}, …}`                   |
+| Operation  | Response payload                                                                         |
+|------------|------------------------------------------------------------------------------------------|
+| `request`  | `data:{"enrollmentId":"<uuid>","status":"pending"}`                                      |
+| `approve`  | `data:{"enrollmentId":"<uuid>","status":"approved"}`                                     |
+| `deny`     | `data:{"enrollmentId":"<uuid>","status":"denied"}`                                       |
+| `revoke`   | `data:{"enrollmentId":"<uuid>","status":"revoked"}` (`:force:` to revoke own enrollment) |
+| `unrevoke` | `data:{"enrollmentId":"<uuid>","status":"approved"}`                                     |
+| `delete`   | `data:{"enrollmentId":"<uuid>","status":"deleted"}`                                      |
+| `fetch`    | `data:{ <full enrollment record JSON> }`                                                 |
+| `list`     | `data:{"<enrollKey>":{<enrollment record JSON>}, …}`                                     |
 
 #### 9.4.2 The `otp` verb
 
@@ -704,6 +714,7 @@ otp:put:<otp>[:ttl:<ms>]
 ```
 
 Source:
+
 ```
 ^otp:(?<operation>get|put)(:(?<otp>(?<=put:)\w{6,}))?(:(?:ttl:(?<ttl>\d+)))?$
 ```
@@ -767,6 +778,7 @@ update[:nc]:json:<json>
 ```
 
 Source:
+
 ```
 ^update(:nc(?<noCommit>))?(:json:(?<json>.+)|<metadataFragment>(:(public|@(?<forAtSign>...)))?:(?<atKey>...)(@(?<atSign>...))? (?<value>.+))$
 ```
@@ -820,6 +832,7 @@ delete[:dAt:<timestamp>][:nc][:force][:priority:<low|medium|high>][:cached][:pub
 ```
 
 Source:
+
 ```
 ^delete(:dAt:...)?(:nc)?(:force)?(:priority:...)?(:cached)?(:public|@<forAtSign>)?:<atKey>(@<atSign>)?$
 ```
@@ -855,6 +868,7 @@ lookup[:bypassCache:<true|false>][:meta|all]:<atKey>@<atSign>
 ```
 
 Source:
+
 ```
 ^lookup:(bypassCache:(?<bypassCache>true|false):)?((?<operation>meta|all):)?(?<atKey>(?:[^:]).+)@(?<atSign>[^:@\s]+)$
 ```
@@ -868,16 +882,19 @@ Source:
 **Response shapes**
 
 Default:
+
 ```
 data:<value>
 ```
 
 `meta:`:
+
 ```
 data:{"createdBy":"@bob","updatedBy":"@bob","createdAt":"…","updatedAt":"…","ttl":null,"ttb":null,"ttr":10000,"ccd":false,"isBinary":false,"isEncrypted":true, …}
 ```
 
 `all:`:
+
 ```
 data:{"key":"@alice:country.wavi@bob","data":"USA","metaData":{ … }}
 ```
@@ -910,6 +927,7 @@ llookup[:meta|all][:cached][:public|@<forAtSign>]:<atKey>@<atSign>
 ```
 
 Source:
+
 ```
 ^llookup(:(?<operation>meta|all))?(:cached)?(:(public|@<forAtSign>))?:<atKey>@<atSign>$
 ```
@@ -929,6 +947,7 @@ scan[:cl][:showhidden:<true|false>][:<forAtSign>][:page:<n>][ <regex>]
 ```
 
 Source:
+
 ```
 ^scan$|scan(:cl)?(:showhidden:...)?(:<forAtSign>)?(:page:...)?( <regex>)?$
 ```
@@ -973,17 +992,17 @@ notify[:id:<id>][:<update|delete>][:messageType:key][:priority:<low|medium|high>
 
 Source: see `at_commons/lib/src/verb/syntax.dart` `notify`.
 
-| Tag             | Description                                                                                           |
-| --------------- | ----------------------------------------------------------------------------------------------------- |
-| `id`            | Caller-supplied notification ID. Server generates one if omitted.                                     |
-| `update|delete` | Operation. Defaults to `update`.                                                                      |
-| `messageType:key` | Notification refers to an atKey change. (`text` exists; **deprecated** — see Appendix B.)            |
-| `priority`      | Delivery priority hint.                                                                               |
-| `strategy:all`  | Deliver every notification (default).                                                                 |
-| `strategy:latest` | Coalesce: deliver only the most recent `<latestN>` for the same atKey if recipient was offline.    |
-| `latestN`       | Coalesce window size. Used with `strategy:latest`.                                                    |
-| `notifier`      | Identifier of the notifying subsystem. Defaults to `SYSTEM`.                                          |
-| `ttln`          | Notification time-to-live in ms. After expiry the server gives up delivering and marks `expired`.    |
+| Tag               | Description                                                                                       |
+|-------------------|---------------------------------------------------------------------------------------------------|
+| `id`              | Caller-supplied notification ID. Server generates one if omitted.                                 |
+| `update           | delete`                                                                                           | Operation. Defaults to `update`.                                                                      |
+| `messageType:key` | Notification refers to an atKey change. (`text` exists; **deprecated** — see Appendix B.)         |
+| `priority`        | Delivery priority hint.                                                                           |
+| `strategy:all`    | Deliver every notification (default).                                                             |
+| `strategy:latest` | Coalesce: deliver only the most recent `<latestN>` for the same atKey if recipient was offline.   |
+| `latestN`         | Coalesce window size. Used with `strategy:latest`.                                                |
+| `notifier`        | Identifier of the notifying subsystem. Defaults to `SYSTEM`.                                      |
+| `ttln`            | Notification time-to-live in ms. After expiry the server gives up delivering and marks `expired`. |
 
 **Response** — `data:<notificationId>` on success.
 
@@ -1021,6 +1040,7 @@ notify:list[:<fromDate>][:<toDate>][:<regex>]
 ```
 
 Dates are `YYYY-MM-DD`. Source:
+
 ```
 ^notify:list(:(?<fromDate>\d{4}-[01]?\d?-[0123]?\d?))?(:(?<toDate>...))?(:(?<regex>[^:]+))?
 ```
@@ -1046,13 +1066,13 @@ notify:status:<notificationId>
 
 **Response** — `data:<status>` where status is one of:
 
-| Status        | Meaning                                                |
-| ------------- | ------------------------------------------------------ |
-| `queued`      | Not yet sent.                                          |
-| `delivered`   | Successfully delivered to the recipient's atServer.    |
-| `undelivered` | Tried and failed; will retry per server policy.        |
-| `errored`     | Delivery errored permanently.                          |
-| `expired`     | TTL elapsed before delivery succeeded.                 |
+| Status        | Meaning                                             |
+|---------------|-----------------------------------------------------|
+| `queued`      | Not yet sent.                                       |
+| `delivered`   | Successfully delivered to the recipient's atServer. |
+| `undelivered` | Tried and failed; will retry per server policy.     |
+| `errored`     | Delivery errored permanently.                       |
+| `expired`     | TTL elapsed before delivery succeeded.              |
 
 ### 11.5 `notify:fetch`
 
@@ -1093,17 +1113,18 @@ monitor[:strict][:selfNotifications][:multiplexed][:<epochMillis>][ <regex>]
 ```
 
 Source:
+
 ```
 ^monitor(:strict)?(:selfNotifications)?(:multiplexed)?(:<epochMillis>)?( <regex>)?$
 ```
 
 | Modifier            | Effect                                                                                              |
-| ------------------- | --------------------------------------------------------------------------------------------------- |
+|---------------------|-----------------------------------------------------------------------------------------------------|
 | `strict`            | Emit **only** notifications matching the regex; suppress server-control notifications (e.g. stats). |
 | `selfNotifications` | Include notifications the connecting atSign emitted itself.                                         |
-| `multiplexed`       | Allow request-response interleaving on the same connection.                                          |
-| `<epochMillis>`     | Replay notifications received at or after this timestamp.                                            |
-| `<regex>`           | Filter notifications by atKey regex.                                                                 |
+| `multiplexed`       | Allow request-response interleaving on the same connection.                                         |
+| `<epochMillis>`     | Replay notifications received at or after this timestamp.                                           |
+| `<regex>`           | Filter notifications by atKey regex.                                                                |
 
 **Response** — a stream. Each notification arrives as one line:
 
@@ -1139,6 +1160,7 @@ sync:from:<from_commit_seq>[:limit:<n>][:skipDeletesUntil:<n>][:<regex>]
 ```
 
 Source:
+
 ```
 ^sync:from:(?<from_commit_seq>[0-9]+|-1)(:limit:(?<limit>\d+))?(:skipDeletesUntil:(?<skipDeletesUntil>\d+))?(:(?<regex>.+))?$
 ```
@@ -1205,6 +1227,7 @@ stats[:<id>[,<id>…]][:<regex>]
 ```
 
 Source:
+
 ```
 ^stats(?<statId>:((?!0)\d+)?(,(\d+))*)?(:(?<regex>(?<=:3:|:15:).+))?$
 ```
@@ -1212,14 +1235,14 @@ Source:
 Without IDs, all statistics are returned. Statistics are identified
 by integer IDs:
 
-| ID  | Name                        | Value type                    |
-| --- | --------------------------- | ----------------------------- |
-| 1   | `activeInboundConnections`  | int                           |
-| 2   | `activeOutboundConnections` | int                           |
-| 3   | `lastCommitId`              | int                           |
-| 4   | `secondaryStorageSize`      | int (bytes)                   |
-| 5   | `topAtSigns`                | `{<atSign>: <hits>, …}`       |
-| 6   | `topKeys`                   | `{<atKey>: <hits>, …}`        |
+| ID | Name                        | Value type              |
+|----|-----------------------------|-------------------------|
+| 1  | `activeInboundConnections`  | int                     |
+| 2  | `activeOutboundConnections` | int                     |
+| 3  | `lastCommitId`              | int                     |
+| 4  | `secondaryStorageSize`      | int (bytes)             |
+| 5  | `topAtSigns`                | `{<atSign>: <hits>, …}` |
+| 6  | `topKeys`                   | `{<atKey>: <hits>, …}`  |
 
 (Servers may expose additional IDs — IDs 11 and 15 take regex filters
 per the syntax; see source for current set.)
@@ -1244,21 +1267,25 @@ info[:brief|mtls|mtlsbrief]
 **Response shapes**
 
 `info` (full):
+
 ```
 data:{"version":"3.0.28","uptimeAsWords":"1 hours 35 minutes 29 seconds","features":[ {…feature record…}, … ]}
 ```
 
 `info:brief`:
+
 ```
 data:{"version":"3.0.28","uptimeAsMillis":5855295}
 ```
 
 `info:mtls`:
+
 ```
 data:{"mtls_fullchain":"<PEM>"}
 ```
 
 `info:mtlsbrief`:
+
 ```
 data:{"mtls_fullchain_last_modified":"2026-05-05T08:00:00.000Z","mtls_privkey_last_modified":"2026-05-05T08:00:00.000Z"}
 ```
@@ -1473,12 +1500,12 @@ B's atSign).
 
 **Failure modes:**
 
-| Cause                                       | Error                                          |
-| ------------------------------------------- | ---------------------------------------------- |
-| `pol` sent without prior `from`             | `error:AT0013-You must execute a 'from:' command before you may run the pol command` |
-| Signature verification fails                | `error:AT0025-Pol Authentication Failed`       |
-| Cannot connect outbound to verify           | `error:AT0007-atServer not found`              |
-| Any other handshake exception               | `error:AT0008-Handshake failure`               |
+| Cause                             | Error                                                                                |
+|-----------------------------------|--------------------------------------------------------------------------------------|
+| `pol` sent without prior `from`   | `error:AT0013-You must execute a 'from:' command before you may run the pol command` |
+| Signature verification fails      | `error:AT0025-Pol Authentication Failed`                                             |
+| Cannot connect outbound to verify | `error:AT0007-atServer not found`                                                    |
+| Any other handshake exception     | `error:AT0008-Handshake failure`                                                     |
 
 ### 15.3 Cross-atSign `lookup`
 
@@ -1750,36 +1777,36 @@ Sorted by code. The "Class" column gives the Dart exception that
 canonically produces the code; implementations in other languages
 should map to an equivalent.
 
-| Code     | Message                                | Class                              | Connection |
-| -------- | -------------------------------------- | ---------------------------------- | ---------- |
-| `AT0001` | Server exception                       | `AtServerException`                | Closed     |
-| `AT0002` | DataStore exception                    | `DataStoreException`               | Closed     |
-| `AT0003` | Invalid syntax                         | `InvalidSyntaxException`           | Closed     |
-| `AT0004` | Socket error                           | `AtIOException`                    | Closed     |
-| `AT0005` | Buffer limit exceeded                  | `BufferOverFlowException`          | Closed     |
-| `AT0006` | Outbound connection limit exceeded     | `OutboundConnectionLimitException` | Open       |
-| `AT0007` | atServer not found                     | `SecondaryNotFoundException`       | Open       |
-| `AT0008` | Handshake failure                      | `HandShakeException`               | Closed     |
-| `AT0009` | UnAuthorized client in the request     | `UnAuthorizedException`            | Closed     |
-| `AT0010` | Internal server error                  | `InternalServerError`              | Closed     |
-| `AT0011` | Internal server exception              | `InternalServerException`          | Closed     |
-| `AT0012` | Inbound connection limit exceeded      | `InboundConnectionLimitException`  | Closed     |
-| `AT0013` | Connection Exception                   | `BlockedConnectionException`       | Closed     |
-| `AT0014` | Unknown AtClient exception             | `AtClientException`                | n/a (client-only) |
-| `AT0015` | Key not found                          | `KeyNotFoundException`             | Open       |
-| `AT0016` | Invalid key                            | `InvalidAtKeyException`            | Open       |
-| `AT0021` | Unable to connect to atServer          | `SecondaryConnectException`        | n/a (client-only) |
-| `AT0022` | Illegal arguments                      | `IllegalArgumentException`         | Open       |
-| `AT0023` | Timeout waiting for response           | `AtTimeoutException`               | Open       |
-| `AT0024` | Server is paused                       | `ServerIsPausedException`          | Open       |
-| `AT0025` | Authentication failed (cram/pol)       | `UnAuthenticatedException`         | Closed     |
-| `AT0026` | APKAM enrollment pending               | `UnAuthenticatedException`         | Closed     |
-| `AT0027` | APKAM enrollment revoked               | `UnAuthenticatedException`         | Closed     |
-| `AT0028` | Too many requests / throttle exceeded  | `AtThrottleLimitExceeded`          | Open       |
-| `AT0029` | APKAM enrollment expired               | `AtInvalidEnrollmentException`     | Closed     |
-| `AT0031` | Cannot revoke own enrollment           | `AtEnrollmentRevokeException`      | Open       |
-| `AT0032` | Illegal state                          | `IllegalStateException`            | Open       |
-| `AT0401` | Client authentication failed (cram/pkam) | `UnAuthenticatedException`       | Closed     |
+| Code     | Message                                  | Class                              | Connection        |
+|----------|------------------------------------------|------------------------------------|-------------------|
+| `AT0001` | Server exception                         | `AtServerException`                | Closed            |
+| `AT0002` | DataStore exception                      | `DataStoreException`               | Closed            |
+| `AT0003` | Invalid syntax                           | `InvalidSyntaxException`           | Closed            |
+| `AT0004` | Socket error                             | `AtIOException`                    | Closed            |
+| `AT0005` | Buffer limit exceeded                    | `BufferOverFlowException`          | Closed            |
+| `AT0006` | Outbound connection limit exceeded       | `OutboundConnectionLimitException` | Open              |
+| `AT0007` | atServer not found                       | `SecondaryNotFoundException`       | Open              |
+| `AT0008` | Handshake failure                        | `HandShakeException`               | Closed            |
+| `AT0009` | UnAuthorized client in the request       | `UnAuthorizedException`            | Closed            |
+| `AT0010` | Internal server error                    | `InternalServerError`              | Closed            |
+| `AT0011` | Internal server exception                | `InternalServerException`          | Closed            |
+| `AT0012` | Inbound connection limit exceeded        | `InboundConnectionLimitException`  | Closed            |
+| `AT0013` | Connection Exception                     | `BlockedConnectionException`       | Closed            |
+| `AT0014` | Unknown AtClient exception               | `AtClientException`                | n/a (client-only) |
+| `AT0015` | Key not found                            | `KeyNotFoundException`             | Open              |
+| `AT0016` | Invalid key                              | `InvalidAtKeyException`            | Open              |
+| `AT0021` | Unable to connect to atServer            | `SecondaryConnectException`        | n/a (client-only) |
+| `AT0022` | Illegal arguments                        | `IllegalArgumentException`         | Open              |
+| `AT0023` | Timeout waiting for response             | `AtTimeoutException`               | Open              |
+| `AT0024` | Server is paused                         | `ServerIsPausedException`          | Open              |
+| `AT0025` | Authentication failed (cram/pol)         | `UnAuthenticatedException`         | Closed            |
+| `AT0026` | APKAM enrollment pending                 | `UnAuthenticatedException`         | Closed            |
+| `AT0027` | APKAM enrollment revoked                 | `UnAuthenticatedException`         | Closed            |
+| `AT0028` | Too many requests / throttle exceeded    | `AtThrottleLimitExceeded`          | Open              |
+| `AT0029` | APKAM enrollment expired                 | `AtInvalidEnrollmentException`     | Closed            |
+| `AT0031` | Cannot revoke own enrollment             | `AtEnrollmentRevokeException`      | Open              |
+| `AT0032` | Illegal state                            | `IllegalStateException`            | Open              |
+| `AT0401` | Client authentication failed (cram/pkam) | `UnAuthenticatedException`         | Closed            |
 
 ### 17.2 Note on `AT0009` vs `AT0401`
 
@@ -1832,38 +1859,39 @@ distinguish between them; clients may retry on `AT0401` but not on
 ## Appendix A — Verb reference
 
 Terse reference for ctrl-F. Authoritative regex source:
-[`at_commons/lib/src/verb/syntax.dart`](https://github.com/atsign-foundation/at_client_sdk/blob/trunk/packages/at_commons/lib/src/verb/syntax.dart).
+[
+`at_commons/lib/src/verb/syntax.dart`](https://github.com/atsign-foundation/at_client_sdk/blob/trunk/packages/at_commons/lib/src/verb/syntax.dart).
 
-| Verb            | Auth | Purpose                                          | Section |
-| --------------- | ---- | ------------------------------------------------ | ------- |
-| `from`          | —    | Identify connecting atSign; receive challenge.   | §9.1    |
-| `cram`          | —    | Bootstrap-only authentication.                    | §9.2    |
-| `pkam`          | —    | Sign-the-challenge authentication.                | §9.3    |
-| `pol`           | —    | Inter-atServer proof-of-life. Server-emitted only.| §15.2   |
-| `enroll`        | varies | APKAM enrollment lifecycle.                      | §9.4.1  |
-| `otp`           | owner | Get/put OTP for APKAM.                            | §9.4.2  |
-| `keys`          | yes  | APKAM-issued key storage. **Being deprecated** — see §9.4.3 and §B.7. | §9.4.3  |
-| `update`        | yes  | Insert/overwrite an atKey.                        | §10.1   |
-| `update:meta`   | yes  | Update only metadata.                             | §10.2   |
-| `delete`        | yes  | Remove an atKey.                                  | §10.3   |
-| `lookup`        | yes  | Cross-atSign read.                                | §10.4   |
-| `plookup`       | —    | Public lookup.                                    | §10.5   |
-| `llookup`       | yes  | Local-server-only lookup.                         | §10.6   |
-| `scan`          | varies | Enumerate atKeys (regex/filter).                  | §10.7   |
-| `notify`        | yes  | Emit a notification.                              | §11.1   |
-| `notify:all`    | yes  | Emit to multiple recipients.                      | §11.2   |
-| `notify:list`   | yes  | List received (or sent, if pol-auth) notifications.| §11.3  |
-| `notify:status` | yes  | Query delivery status.                            | §11.4   |
-| `notify:fetch`  | yes  | Fetch full notification record.                   | §11.5   |
-| `notify:remove` | yes  | Remove from local notification log.               | §11.6   |
-| `monitor`       | yes  | Stream of received notifications.                 | §11.7   |
-| `sync:from`     | yes  | Walk the commit log from an offset.               | §12.1   |
-| `config`        | owner | Block-list and config management.                 | §13.1   |
-| `stats`         | yes  | Server statistics.                                | §13.2   |
-| `info`          | varies | Server runtime info.                              | §13.3   |
-| `noop`          | —    | Sleep then `data:ok`.                             | §13.4   |
-| `batch`         | yes  | Multiple verbs in one round-trip.                 | §13.5   |
-| `@exit`         | —    | atDirectory graceful close.                       | §8.4    |
+| Verb            | Auth   | Purpose                                                               | Section |
+|-----------------|--------|-----------------------------------------------------------------------|---------|
+| `from`          | —      | Identify connecting atSign; receive challenge.                        | §9.1    |
+| `cram`          | —      | Bootstrap-only authentication.                                        | §9.2    |
+| `pkam`          | —      | Sign-the-challenge authentication.                                    | §9.3    |
+| `pol`           | —      | Inter-atServer proof-of-life. Server-emitted only.                    | §15.2   |
+| `enroll`        | varies | APKAM enrollment lifecycle.                                           | §9.4.1  |
+| `otp`           | owner  | Get/put OTP for APKAM.                                                | §9.4.2  |
+| `keys`          | yes    | APKAM-issued key storage. **Being deprecated** — see §9.4.3 and §B.7. | §9.4.3  |
+| `update`        | yes    | Insert/overwrite an atKey.                                            | §10.1   |
+| `update:meta`   | yes    | Update only metadata.                                                 | §10.2   |
+| `delete`        | yes    | Remove an atKey.                                                      | §10.3   |
+| `lookup`        | yes    | Cross-atSign read.                                                    | §10.4   |
+| `plookup`       | —      | Public lookup.                                                        | §10.5   |
+| `llookup`       | yes    | Local-server-only lookup.                                             | §10.6   |
+| `scan`          | varies | Enumerate atKeys (regex/filter).                                      | §10.7   |
+| `notify`        | yes    | Emit a notification.                                                  | §11.1   |
+| `notify:all`    | yes    | Emit to multiple recipients.                                          | §11.2   |
+| `notify:list`   | yes    | List received (or sent, if pol-auth) notifications.                   | §11.3   |
+| `notify:status` | yes    | Query delivery status.                                                | §11.4   |
+| `notify:fetch`  | yes    | Fetch full notification record.                                       | §11.5   |
+| `notify:remove` | yes    | Remove from local notification log.                                   | §11.6   |
+| `monitor`       | yes    | Stream of received notifications.                                     | §11.7   |
+| `sync:from`     | yes    | Walk the commit log from an offset.                                   | §12.1   |
+| `config`        | owner  | Block-list and config management.                                     | §13.1   |
+| `stats`         | yes    | Server statistics.                                                    | §13.2   |
+| `info`          | varies | Server runtime info.                                                  | §13.3   |
+| `noop`          | —      | Sleep then `data:ok`.                                                 | §13.4   |
+| `batch`         | yes    | Multiple verbs in one round-trip.                                     | §13.5   |
+| `@exit`         | —      | atDirectory graceful close.                                           | §8.4    |
 
 ---
 
@@ -2002,7 +2030,8 @@ envelope.
 Cleanup of the exception hierarchy, error-code emission, and
 on-the-wire `error:…` shapes. Implementers should expect the error
 catalogue in §17 to gain entries (and possibly normalise the
-hyphen/colon separator inconsistency noted in [§D.1](#d1-error-code-separator-hyphen-vs-colon)).
+hyphen/colon separator inconsistency noted
+in [§D.1](#d1-error-code-separator-hyphen-vs-colon)).
 
 ### C.5 Canonical SDK conformance test suite
 
@@ -2065,7 +2094,8 @@ the SDK; not a wire-protocol change.
 [at_server #2568](https://github.com/atsign-foundation/at_server/issues/2568).
 Today, looking up a key whose `eAt` has passed returns `data:null`;
 the proposed correction is `error:AT0015-Key not found`. A small
-change but observable on the wire — see [§D.4](#d4-expired-keys-return-null-instead-of-an-at0015-error).
+change but observable on the wire —
+see [§D.4](#d4-expired-keys-return-null-instead-of-an-at0015-error).
 
 ---
 
@@ -2262,6 +2292,7 @@ carry one or the other, never both meaningfully — see Appendix B.4.
 Session IDs (`<sessionID>` in `from`/`pol`) are produced server-side
 and have a leading `_` followed by a UUID, e.g.
 `_4af24c03-d732-48f8-a9a2-570e8fb6a01c`. The leading underscore
-matters: it makes the per-session keystore entries (`public:<sessionID><atSign>`)
+matters: it makes the per-session keystore entries (
+`public:<sessionID><atSign>`)
 "hidden" by atKey-shape rules and so they don't appear in `scan`
 output without `:showhidden:true`.

--- a/specification/atsign_protocol_specification.md
+++ b/specification/atsign_protocol_specification.md
@@ -1,7 +1,9 @@
 # Atsign Protocol Specification
 
+<!-- pyml disable-num-lines 3000 md013-->
+
 This document specifies the **Atsign Protocol** at the level required to
-implement either side of the wire — an atClient or an atServer — in any
+implement either side of the wire, an atClient or an atServer, in any
 language. Every byte that crosses a TCP socket between an atClient,
 atServer, or atDirectory is in scope. Higher-level concerns that are
 client-only (file formats, key derivation, query languages) are out of
@@ -41,29 +43,31 @@ wins and this document is a bug. Pull requests welcomed.
 16. [Worked flows](#16-worked-flows)
 17. [Errors](#17-errors)
 18. [Glossary](#18-glossary)
-19. [Appendix A — Verb reference](#appendix-a--verb-reference)
-20. [Appendix B — Legacy and deprecated](#appendix-b--legacy-and-deprecated)
-21. [Appendix C — Significant near-term projects](#appendix-c--significant-near-term-projects)
-22. [Appendix D — Inconsistencies and quirks](#appendix-d--inconsistencies-and-quirks)
+19. [Appendix A, Verb reference](#appendix-a-verb-reference)
+20. [Appendix B, Legacy and deprecated](#appendix-b-legacy-and-deprecated)
+21. [Appendix C, Significant near-term projects](#appendix-c-significant-near-term-projects)
+22. [Appendix D, Inconsistencies and quirks](#appendix-d-inconsistencies-and-quirks)
 
 ---
 
 ## 1. Introduction
 
 The Atsign Protocol is a text-based, line-oriented, request/response
-protocol over TLS. Three roles participate:
+protocol over TLS. Three roles participate.
 
-- **atClient** — software acting on behalf of an atSign owner. Talks to
-  exactly one atServer at a time (the owner's atServer or a
-  remote-owner's atServer for cross-atSign reads/writes).
-- **atServer** — the personal server for one atSign. Stores that
-  atSign's keys (encrypted blobs at rest), serves them on request,
-  delivers notifications, and connects out to other atServers when its
-  owner's atClient asks for cross-atSign data.
-- **atDirectory** — a lookup service that maps an atSign to the
-  `host:port` of its atServer. Conceptually similar to DNS.
+An **atClient** is software acting on behalf of an atSign owner. It
+talks to exactly one atServer at a time, either the owner's atServer
+or a remote-owner's atServer for cross-atSign reads and writes.
 
-The protocol is built around a small set of **verbs** — single-line
+An **atServer** is the personal server for one atSign. It stores that
+atSign's keys (encrypted blobs at rest), serves them on request,
+delivers notifications, and connects out to other atServers when its
+owner's atClient asks for cross-atSign data.
+
+An **atDirectory** is a lookup service that maps an atSign to the
+`host:port` of its atServer. It is conceptually similar to DNS.
+
+The protocol is built around a small set of **verbs**, single-line
 commands a client sends to a server. Each verb has a regex-defined
 syntax. Servers respond with a single line of `data:…` or `error:…`,
 followed by a prompt that frames the next request. Two verbs (`monitor`
@@ -73,42 +77,37 @@ responses; everything else is single-shot.
 End-to-end encryption is **entirely an atClient concern**. atServers
 store opaque ciphertext and opaque metadata fields, and never see
 plaintext values. Server-side filtering on values is therefore
-architecturally impossible — see [§14](#14-end-to-end-encryption).
+architecturally impossible, see [§14](#14-end-to-end-encryption).
 
-### For implementers — read these first
+### For implementers, read these first
 
 Two appendices are load-bearing for anyone implementing this
 specification:
 
--
-    *
-*[Appendix C — Significant near-term projects](#appendix-c--significant-near-term-projects)
-**
-enumerates active workstreams that will change parts of this
-specification within the next few releases (post-quantum
-cryptography, fast-sync / "fsync", new atKeys structure, pluggable
-encryption, canonical conformance test suite, etc.). Read this
-before committing to a long-lived implementation choice.
--
-    *
-*[Appendix D — Inconsistencies and quirks](#appendix-d--inconsistencies-and-quirks)
-**
-enumerates the places where the wire reality is surprising — error
-separators that aren't uniform, response shapes that differ
-per-verb, semantics that flip on auth state, and similar gotchas.
-Read this if your implementation is failing in ways that the
-per-verb sections don't seem to predict.
+- [Appendix C, Significant near-term projects](#appendix-c-significant-near-term-projects)
+  enumerates active workstreams that will change parts of this
+  specification within the next few releases (post-quantum
+  cryptography, fast-sync / "fsync", new atKeys structure, pluggable
+  encryption, canonical conformance test suite, etc.). Read this
+  before committing to a long-lived implementation choice.
+
+- [Appendix D, Inconsistencies and quirks](#appendix-d-inconsistencies-and-quirks)
+  enumerates the places where the wire reality is surprising, error
+  separators that aren't uniform, response shapes that differ
+  per-verb, semantics that flip on auth state, and similar gotchas.
+  Read this if your implementation is failing in ways that the
+  per-verb sections don't seem to predict.
 
 ### Spelling and capitalisation
 
 The protocol's name is **Atsign Protocol** (capital A, capital P,
 single-spaced). The domain terms are:
 
-- `atSign` — an identity like `@alice`
-- `atServer` — the personal server for an atSign
-- `atDirectory` — the directory service
-- `atKey` — a key in an atServer's keystore
-- `atClient` — software talking to atServers
+- `atSign`, an identity like `@alice`
+- `atServer`, the personal server for an atSign
+- `atDirectory`, the directory service
+- `atKey`, a key in an atServer's keystore
+- `atClient`, software talking to atServers
 
 Preserve those capitalisations exactly in code and docs.
 
@@ -133,7 +132,7 @@ Three deployment modes are commonly seen:
    runs its own atServers, but the atSigns are still resolvable via
    `root.atsign.org:64`. The atDirectory entry points at the
    organisation's hosts.
-3. **Fully self-hosted (split-horizon).** An organisation runs its own
+3. **Fully self-hosted.** An organisation runs its own
    atDirectory **and** its own atServers, with atSign registration and
    provisioning entirely under its control. atSigns hosted in this
    topology are not resolvable on the public Atsign Protocol; clients
@@ -149,23 +148,24 @@ A hard-coded `root.atsign.org:64` is not Atsign-Protocol-compliant.
 
 ### 3.1 atDirectory
 
-- **Transport:** TCP.
-- **TLS:** **One-way TLS** — the atDirectory presents a server
-  certificate; the client does not present one.
-- **Default port:** `64`.
-- **Default host:** `root.atsign.org` (configurable).
+| Property     | Value                                                      |
+|--------------|------------------------------------------------------------|
+| Transport    | TCP                                                        |
+| TLS          | One-way (atDirectory presents a server certificate; client does not) |
+| Default port | `64`                                                       |
+| Default host | `root.atsign.org` (configurable)                           |
 
 ### 3.2 atServer
 
-- **Transport:** TCP.
-- **TLS:** **One-way TLS by default.** Some deployments require client
-  certificates (mTLS) for atServer-to-atServer connections — the
-  outbound connection factory chooses based on configuration. mTLS is
-  not used between atClients and atServers in the default
-  configuration.
-- **Port:** Per-atSign. Discovered via the atDirectory. The atDirectory
-  response is the canonical source for the host and port to connect
-  to.
+The atServer transport is TCP with one-way TLS by default. Some
+deployments require client certificates (mTLS) for
+atServer-to-atServer connections; the outbound connection factory
+chooses based on configuration. mTLS is not used between atClients
+and atServers in the default configuration.
+
+The port is per-atSign and is discovered via the atDirectory. The
+atDirectory response is the canonical source for the host and port to
+connect to.
 
 ### 3.3 Connection lifecycle
 
@@ -176,11 +176,11 @@ A hard-coded `root.atsign.org:64` is not Atsign-Protocol-compliant.
    waits for the client's first verb.
 4. Client sends verb, terminated by `\n`.
 5. Server responds with `data:…\n@…@` or `error:…\n@…@`. The trailing
-   `@…@` (or bare `@` before authentication) is the **prompt** — see
+   `@…@` (or bare `@` before authentication) is the **prompt**, see
    [§4](#4-framing).
 6. Steps 4–5 repeat. Either side may close the connection at any time;
    the client may signal a graceful close with `@exit\n` (atDirectory
-   only) or by simply closing the socket.
+   only) or by closing the socket.
 
 ### 3.4 Idle and timeout behaviour
 
@@ -225,7 +225,7 @@ detect "response complete" by scanning for the byte sequence `\n@`.
 Source: `at_lookup/lib/src/connection/outbound_message_listener.dart`
 treats `\n` followed by `@` as the frame boundary.
 
-```
+```text
 data:42\n@alice@
 ^^^^^^^^^^^^^^^^^
 | response data | prompt
@@ -239,14 +239,14 @@ is parsing incorrectly.
 
 UTF-8. atKeys, values, and metadata are all UTF-8 strings on the wire.
 
-### 4.4 Newline escaping in values
+### 4.4 Newline escapes in values
 
 Because `\n` is the framing terminator, an atServer rewrites embedded
 newlines in **public** data values: `\n` becomes the literal
-six-character sequence `~NL~` on the wire. Clients writing values that
+4-character sequence `~NL~` on the wire. Clients writing values that
 contain newlines apply the same escape; clients reading public values
 reverse it. The escape is not applied to encrypted (binary)
-ciphertext — that is base64-encoded and so contains no `\n` to begin
+ciphertext, that is base64-encoded and so contains no `\n` to begin
 with.
 
 ### 4.5 Binary values
@@ -270,7 +270,7 @@ connection. A client must not send a second verb before reading the
 first verb's complete response (terminated by the prompt). The
 exception is `monitor`, which streams notifications continuously and
 optionally accepts request-response interleaving when `:multiplexed:`
-is set — see [§11.7](#117-monitor).
+is set, see [§11.7](#117-monitor).
 
 ---
 
@@ -278,7 +278,7 @@ is set — see [§11.7](#117-monitor).
 
 An **atSign** is a unique identifier of the form `@<name>` where
 `<name>` matches `[^@:\s]+`. Comparison is case-preserving but
-case-insensitive on the wire — `@Alice` and `@alice` resolve to the
+case-insensitive on the wire, `@Alice` and `@alice` resolve to the
 same identity (atServers normalise to lowercase before keystore
 lookup).
 
@@ -288,7 +288,7 @@ The maximum atSign length is **55 characters** including the leading
 ### 5.1 Lifecycle phases
 
 The full lifecycle of an atSign from registration to active use breaks
-into three phases. The `at_auth` package documents this in detail; the
+into 3 phases. The `at_auth` package documents this in detail; the
 phases are summarised here because each produces credentials that
 appear on the wire.
 
@@ -301,7 +301,7 @@ appear on the wire.
    stores the private halves locally (`.atKeys` file or device
    keychain). After onboarding, the CRAM secret is no longer accepted.
 3. **Authenticate (per app).** Subsequent apps authenticate via
-   **APKAM enrollment** — they request a scoped key set bound to a
+   **APKAM enrollment**, they request a scoped key set bound to a
    namespace permission map (e.g. `{'todos': 'rw'}`); the master-keys
    holder approves; the atServer issues new scoped credentials.
    APKAM-issued keys are revocable.
@@ -313,11 +313,11 @@ PKAM (with or without APKAM scoping). See [§9](#9-authentication).
 
 ## 6. The atKey model
 
-A key in the atServer's keystore is an **atKey** — a structured string
-whose shape encodes its visibility and ownership. There are five key
-shapes plus two augmentations.
+A key in the atServer's keystore is an **atKey**, a structured string
+whose shape encodes its visibility and ownership. There are 5 key
+shapes plus 2 augmentations.
 
-### 6.1 The five shapes
+### 6.1 The 5 shapes
 
 | Shape   | Wire format                                | Visibility                                         |
 |---------|--------------------------------------------|----------------------------------------------------|
@@ -329,15 +329,17 @@ shapes plus two augmentations.
 
 ### 6.2 Augmentations
 
-- **Hidden** — if the `<key>` part starts with `_`, the key is not
-  returned by `scan` unless the caller passes `:showhidden:true`.
-  Public, self, and shared keys may all be hidden.
-- **Cached** — a copy of a remote-owned shared or public key, stored on
-  the recipient's atServer for offline / fast access. Wire format:
-  `cached:public:<key>@<owner>` or `cached:@<recipient>:<key>@<owner>`.
-  The recipient's atServer refreshes the cache per the original key's
-  `ttr` (time-to-refresh) and deletes it on owner-side delete if `ccd`
-  is set.
+A **hidden** key is one whose `<key>` part starts with `_`. The atServer
+omits hidden keys from the `scan` verb's output unless the caller
+passes `:showhidden:true`. Public, self, and shared keys may all be
+hidden.
+
+A **cached** key is a copy of a remote-owned shared or public key,
+stored on the recipient's atServer for offline or fast access. Wire
+format is `cached:public:<key>@<owner>` or
+`cached:@<recipient>:<key>@<owner>`. The recipient's atServer refreshes
+the cache per the original key's `ttr` (time-to-refresh) and deletes
+it on owner-side delete if `ccd` is set.
 
 ### 6.3 Namespace
 
@@ -354,7 +356,7 @@ infrastructural item (atSign-wide encryption keys, e.g.
 
 The maximum on-wire length of an atKey is **255 characters**
 inclusive of all segments and separators. Compute against this hard
-cap, not a typical size — atSigns alone may consume up to 55
+cap, not a typical size, atSigns alone may consume up to 55
 characters of the budget.
 
 ### 6.5 Reserved keys
@@ -377,7 +379,7 @@ These are required for the protocol to function and have stable names:
 APKAM-issued keys live under the `__pkams` and `__manage` reserved
 namespaces.
 
-### 6.6 atKey parsing examples
+### 6.6 atKey examples
 
 | Wire form                       | Shape   | Hidden? | Cached? |
 |---------------------------------|---------|---------|---------|
@@ -434,7 +436,7 @@ Source of truth: `at_commons/lib/src/verb/syntax.dart`'s
 
 Negative integer values for `ttl`/`ttb` are accepted by the regex (the
 syntax allows `(-?)\d+`) but server-side semantics are documented at
-the constants level — typically only `ttr:-1` ("cache forever") is a
+the constants level, typically only `ttr:-1` ("cache forever") is a
 useful negative.
 
 ### 7.2 Tag ordering
@@ -464,18 +466,17 @@ prompt.
 
 Send the atSign followed by `\n`. Either form is accepted:
 
-```
+```text
 @alice\n
 alice\n
 ```
 
 ### 8.3 Response
 
-Two possible replies:
-
-- **Found:** `<host>:<port>\n@` — `host` is a hostname or IP, `port` is
-  the atServer's TLS port for that atSign.
-- **Not found:** `null\n@`
+When the atSign is found, the atDirectory replies with
+`<host>:<port>\n@`, where `host` is a hostname or IP and `port` is the
+atServer's TLS port for that atSign. When the atSign is not found, the
+reply is `null\n@`.
 
 Some atDirectory implementations emit `\r\n@` instead of `\n@`;
 implementations should accept both.
@@ -487,7 +488,7 @@ flush and close the socket. No response is expected.
 
 ### 8.5 Worked example
 
-```
+```text
 C: <TLS handshake>
 S: @
 C: @alice\n
@@ -503,7 +504,7 @@ lookups; any other input is treated as an atSign to look up.
 
 ## 9. Authentication
 
-The atServer recognises three authentication mechanisms, all built on
+The atServer recognises 3 authentication mechanisms, all built on
 the same `from`-then-prove choreography. Modern atClients use **APKAM**
 exclusively, with **CRAM** appearing only during one-time onboarding.
 
@@ -513,15 +514,15 @@ exclusively, with **CRAM** appearing only during one-time onboarding.
 server which atSign is connecting and, for non-self connections, who
 the server should expect to authenticate via `pol`.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 from:<atSign>[:clientConfig:<clientConfig-json>]
 ```
 
 Source: `at_commons/lib/src/verb/syntax.dart`:
 
-```
+```text
 ^from:(?<atSign>@?[^:@\s]+)(:clientConfig:(?<clientConfig>\{.+\}))?$
 ```
 
@@ -539,7 +540,7 @@ metadata:
 
 Unrecognised fields are ignored.
 
-**Response** — the server generates a UUIDv4 challenge and a session
+Response: the server generates a UUIDv4 challenge and a session
 ID and stores the challenge under
 `<keyPrefix><sessionId><fromAtSign>` (with TTL 60 s), where
 `keyPrefix` is `private:` if the connecting atSign matches the
@@ -548,19 +549,19 @@ matters for `pol`, which retrieves the challenge via `plookup`).
 
 The response payload is:
 
-```
+```text
 data:<sessionId><fromAtSign>:<proof>      # if self-connect
 data:proof:<sessionId><fromAtSign>:<proof> # if cross-atSign connect
 ```
 
-— each followed by the unauthenticated prompt `\n@`.
+Each is followed by the unauthenticated prompt `\n@`.
 
 Source: `at_secondary_server/lib/src/verb/handler/from_verb_handler.dart`
 lines 74–103.
 
-**Example** — self-connect by `@alice` to `@alice`'s atServer:
+Example: self-connect by `@alice` to `@alice`'s atServer:
 
-```
+```text
 C: from:@alice\n
 S: data:_4af24c03-d732-48f8-a9a2-570e8fb6a01c@alice:d6cac849-9c29-42b0-b0c5-493db62728b9\n@
 ```
@@ -573,30 +574,30 @@ clients must use PKAM/APKAM. CRAM remains in the protocol because
 onboarding from a fresh atServer requires a credential that exists
 before any keypair has been generated.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 cram:<digest>
 ```
 
 Source:
 
-```
+```text
 ^cram:(?<digest>.+$)
 ```
 
-**Digest computation** — the client takes the `from` response, strips
+Digest computation: the client takes the `from` response, strips
 the leading `data:` prefix, and computes:
 
-```
+```text
 digest = sha512_hex( utf8( <cramSecret> + <strippedFromResponse> ) )
 ```
 
 For a self-connect, `<strippedFromResponse>` is
-`<sessionId><atSign>:<proof>` — the entire body with no further
+`<sessionId><atSign>:<proof>`, the entire body with no further
 parsing. Source: `at_lookup/lib/src/at_lookup_impl.dart` lines 540–544.
 
-**Response**
+#### Response
 
 - Success: `data:success\n@<atSign>@`
 - Failure: `error:AT0401-Client authentication failed\n@` (connection
@@ -610,19 +611,19 @@ Plain PKAM is the underlying signature-based authentication that APKAM
 extends. A client running plain PKAM holds the master signing private
 key directly.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 pkam:[signingAlgo:<rsa2048|ecc_secp256r1>:][hashingAlgo:<sha256|sha512>:][enrollmentId:<id>:]<signature>
 ```
 
 Source:
 
-```
+```text
 ^pkam:(signingAlgo:(?<signingAlgo>ecc_secp256r1|rsa2048):)?(hashingAlgo:(?<hashingAlgo>sha256|sha512):)?(enrollmentId:(?<enrollmentId>.+):)?(?<signature>.+$)
 ```
 
-**Signature computation** — the client signs the `from` challenge
+Signature computation: the client signs the `from` challenge
 (everything the `from` response payload contained, less any leading
 `data:`) with the owner's signing private key, base64-encodes the
 result, and sends it as `<signature>`.
@@ -632,7 +633,7 @@ is omitted for plain PKAM; an APKAM-issued credential includes the
 enrollment's ID so the atServer can look up the namespace permission
 map.
 
-**Response** — same as CRAM: `data:success` on success,
+Response: same as CRAM: `data:success` on success,
 `error:AT0401-…` on failure.
 
 ### 9.4 APKAM (`enroll`, `otp`, `keys`)
@@ -644,33 +645,33 @@ atSign owner.
 
 A high-level flow:
 
-1. **Bootstrap atSign** — the new app generates a fresh APKAM keypair
+1. **Bootstrap atSign**, the new app generates a fresh APKAM keypair
    and a fresh APKAM symmetric key.
-2. **Get an OTP** — the user, on a session already authenticated as
+2. **Get an OTP**, the user, on a session already authenticated as
    owner, runs `otp:get` and reads the OTP to the new app.
-3. **`enroll:request`** — the new app submits the request, including
+3. **`enroll:request`**, the new app submits the request, including
    its APKAM public key, the OTP, the namespace permission map, and
    the APKAM symmetric key encrypted with the **default encryption
    public key** (so only an owner-keys holder can decrypt it).
-4. **`enroll:approve`** — the owner-keys holder fetches the request,
+4. **`enroll:approve`**, the owner-keys holder fetches the request,
    decrypts the APKAM symmetric key, then sends back the
    default encryption private key and self-encryption key, each
    encrypted with the now-shared APKAM symmetric key (with IVs).
-5. **PKAM-with-enrollmentId** — the new app authenticates as usual via
+5. **PKAM-with-enrollmentId**, the new app authenticates as usual via
    `from` + `pkam`, passing `enrollmentId:<id>` so the atServer scopes
    the connection to the granted namespaces.
 
 #### 9.4.1 The `enroll` verb
 
-**Syntax**
+#### Syntax
 
-```
+```text
 enroll:<operation>[:force][:<enrollParams-json>]
 ```
 
 Source:
 
-```
+```text
 ^enroll:(?<operation>(?:(request|approve|deny|revoke|list|fetch|unrevoke|delete)))(:(?<force>force))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$
 ```
 
@@ -693,7 +694,7 @@ Source:
 | `enrollmentStatusFilter`               | list                                      | Optional list of statuses to filter on: `pending`, `approved`, `denied`, `revoked`, `expired`. |
 | `apkamKeysExpiryDuration`              | request                                   | ISO-8601 duration: lifetime of the APKAM credentials before forced re-enrollment.              |
 
-**Operations and responses**
+#### Operations and responses
 
 | Operation  | Response payload                                                                         |
 |------------|------------------------------------------------------------------------------------------|
@@ -708,22 +709,22 @@ Source:
 
 #### 9.4.2 The `otp` verb
 
-```
+```text
 otp:get[:ttl:<ms>]
 otp:put:<otp>[:ttl:<ms>]
 ```
 
 Source:
 
-```
+```text
 ^otp:(?<operation>get|put)(:(?<otp>(?<=put:)\w{6,}))?(:(?:ttl:(?<ttl>\d+)))?$
 ```
 
-- `otp:get` — owner-authenticated. Returns a fresh 6-character
+- `otp:get`, owner-authenticated. Returns a fresh 6-character
   alphanumeric OTP. Used as the `otp` field of `enroll:request`.
-- `otp:put:<otp>` — owner-authenticated. Stores a semi-permanent OTP
+- `otp:put:<otp>`, owner-authenticated. Stores a semi-permanent OTP
   for use in headless / CLI enrollment flows.
-- `:ttl:<ms>` — sets the OTP validity window.
+- `:ttl:<ms>`, sets the OTP validity window.
 
 **Response**: `data:<otp>` (for `get`) or `data:ok` (for `put`).
 
@@ -731,15 +732,15 @@ Source:
 
 > **Status: being deprecated.** New implementations should not produce
 > `keys` verbs. The current APKAM enrollment flow still emits them
-> under the covers, but the verb is on the path to removal — it
+> under the covers, but the verb is on the path to removal, it
 > overlaps with `update`/`llookup`/`delete` against the
 > `__pkams` / `__manage` namespaces and adds parsing surface without
 > adding capability. Track the deprecation work alongside the
 > [new AtKeys structure](#c3-new-atkeys-structure) and
 > [pluggable encryption](#c1-post-quantum-cryptography-and-crypto-agility)
-> projects in Appendix C — both intersect with this verb's role.
+> projects in Appendix C, both intersect with this verb's role.
 
-```
+```text
 keys:<put|get|delete>[:public|private|self][:namespace:<ns>][:appName:<n>][:deviceName:<n>][:keyType:<t>][:encryptionKeyName:<n>][:keyName:<n>] [<value>]
 ```
 
@@ -765,47 +766,47 @@ the dedicated `plookup` verb.
 
 Insert or overwrite a value, optionally with metadata.
 
-**Syntax (positional form)**
+#### Syntax (positional form)
 
-```
+```text
 update[:nc]<metadata>[:public|@<forAtSign>]:<atKey>[@<atSign>] <value>
 ```
 
-**Syntax (JSON form)**
+#### Syntax (JSON form)
 
-```
+```text
 update[:nc]:json:<json>
 ```
 
 Source:
 
-```
+```text
 ^update(:nc(?<noCommit>))?(:json:(?<json>.+)|<metadataFragment>(:(public|@(?<forAtSign>...)))?:(?<atKey>...)(@(?<atSign>...))? (?<value>.+))$
 ```
 
 `:nc` (no-commit) suppresses the commit-log entry, used for local
 keys that should not be synced.
 
-**Response** — `data:<commitId>` where `commitId` is the integer
+Response: `data:<commitId>` where `commitId` is the integer
 commit-log sequence number assigned to the operation. Self-connected
 clients use this to detect that their local cache is at least as
 fresh as the server.
 
-```
+```text
 C: update:@bob:phone.wavi@alice +1 555 0100\n
 S: data:42\n@alice@
 ```
 
 Setting metadata at update time:
 
-```
+```text
 C: update:ttr:60000:ccd:true:isEncrypted:true:@bob:secret.myapp@alice <ciphertext>\n
 S: data:43\n@alice@
 ```
 
 JSON form (atomic put with full metadata):
 
-```
+```text
 C: update:json:{"atKey":{"key":"phone","sharedWith":"@bob","sharedBy":"@alice","namespace":"wavi"},"value":"+1 555 0100","metadata":{"ttl":60000}}\n
 S: data:44\n@alice@
 ```
@@ -816,7 +817,7 @@ Update only the metadata of an existing key. Same metadata fragment as
 `update`. Useful for changing TTL or marking a key encrypted after
 the fact.
 
-```
+```text
 C: update:meta:@bob:phone.wavi@alice:ttl:600000:isEncrypted:true\n
 S: data:45\n@alice@
 ```
@@ -825,77 +826,77 @@ S: data:45\n@alice@
 
 Remove an atKey.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 delete[:dAt:<timestamp>][:nc][:force][:priority:<low|medium|high>][:cached][:public|@<forAtSign>]:<atKey>[@<atSign>]
 ```
 
 Source:
 
-```
+```text
 ^delete(:dAt:...)?(:nc)?(:force)?(:priority:...)?(:cached)?(:public|@<forAtSign>)?:<atKey>(@<atSign>)?$
 ```
 
-- `:dAt:<timestamp>` — assert deletion time (used by sync).
-- `:nc` — no commit.
-- `:force` — required to delete an `immutable:true` key.
-- `:cached` — delete a cached copy on this server (does not affect the
+- `:dAt:<timestamp>`, assert deletion time (used by sync).
+- `:nc`, no commit.
+- `:force`, required to delete an `immutable:true` key.
+- `:cached`, delete a cached copy on this server (does not affect the
   origin).
 
-**Response** — `data:<commitId>` (yes, even when the key didn't exist
-— `delete` is idempotent and always commits).
+Response: `data:<commitId>` (yes, even when the key didn't exist;
+`delete` is idempotent and always commits).
 
-```
+```text
 C: delete:@bob:phone.wavi@alice\n
 S: data:46\n@alice@
 ```
 
 If `autoNotify` is enabled and the key was a shared key with a
 recipient on a different atServer, the server emits a `notify:delete`
-to the recipient — see [§11](#11-notification-verbs).
+to the recipient, see [§11](#11-notification-verbs).
 
 ### 10.4 `lookup`
 
 Read a value from another atSign's atServer (cross-atSign read,
 authenticated). Internally proxied via the requestor's local atServer
-— see [§15](#15-the-inter-atserver-protocol).
+(see [§15](#15-the-inter-atserver-protocol)).
 
-**Syntax**
+#### Syntax
 
-```
+```text
 lookup[:bypassCache:<true|false>][:meta|all]:<atKey>@<atSign>
 ```
 
 Source:
 
-```
+```text
 ^lookup:(bypassCache:(?<bypassCache>true|false):)?((?<operation>meta|all):)?(?<atKey>(?:[^:]).+)@(?<atSign>[^:@\s]+)$
 ```
 
 - Default operation: returns the value only.
-- `meta:` — return metadata only.
-- `all:` — return both value and metadata.
-- `bypassCache:true` — force a fetch from the remote rather than
+- `meta:`, return metadata only.
+- `all:`, return both value and metadata.
+- `bypassCache:true`, force a fetch from the remote rather than
   returning a cached copy.
 
-**Response shapes**
+#### Response shapes
 
 Default:
 
-```
+```text
 data:<value>
 ```
 
 `meta:`:
 
-```
+```text
 data:{"createdBy":"@bob","updatedBy":"@bob","createdAt":"…","updatedAt":"…","ttl":null,"ttb":null,"ttr":10000,"ccd":false,"isBinary":false,"isEncrypted":true, …}
 ```
 
 `all:`:
 
-```
+```text
 data:{"key":"@alice:country.wavi@bob","data":"USA","metaData":{ … }}
 ```
 
@@ -903,13 +904,13 @@ If the remote atServer is unreachable: `error:AT0007-atServer not found.`
 
 ### 10.5 `plookup`
 
-Public lookup — read a public key from any atSign without
+Public lookup, read a public key from any atSign without
 authentication. The server may answer from its own cache (per the
 key's `ttr`) unless `:bypassCache:true:` is set.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 plookup[:bypassCache:<true|false>][:meta|all]:<atKey>@<atSign>
 ```
 
@@ -917,22 +918,22 @@ Same response shape as `lookup`.
 
 ### 10.6 `llookup`
 
-Local lookup — read a key from this atServer's own keystore. Returns
+Local lookup, read a key from this atServer's own keystore. Returns
 the stored value verbatim (no resolution, no remote fetch).
 
-**Syntax**
+#### Syntax
 
-```
+```text
 llookup[:meta|all][:cached][:public|@<forAtSign>]:<atKey>@<atSign>
 ```
 
 Source:
 
-```
+```text
 ^llookup(:(?<operation>meta|all))?(:cached)?(:(public|@<forAtSign>))?:<atKey>@<atSign>$
 ```
 
-- `:cached:` — look up a cached copy on this atServer.
+- `:cached:`, look up a cached copy on this atServer.
 
 Response is identical in shape to `lookup`.
 
@@ -940,34 +941,34 @@ Response is identical in shape to `lookup`.
 
 Enumerate keys.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 scan[:cl][:showhidden:<true|false>][:<forAtSign>][:page:<n>][ <regex>]
 ```
 
 Source:
 
-```
+```text
 ^scan$|scan(:cl)?(:showhidden:...)?(:<forAtSign>)?(:page:...)?( <regex>)?$
 ```
 
-- `:cl` — scan the commit log instead of the keystore.
-- `:showhidden:true` — include keys whose `<key>` starts with `_`.
-- `:<forAtSign>` — only return keys shared with that atSign.
-- `:page:<n>` — pagination index (server-defined page size).
-- `<regex>` (space-separated) — filter results by regex.
+- `:cl`, scan the commit log instead of the keystore.
+- `:showhidden:true`, include keys whose `<key>` starts with `_`.
+- `:<forAtSign>`, only return keys shared with that atSign.
+- `:page:<n>`, pagination index (server-defined page size).
+- `<regex>` (space-separated), filter results by regex.
 
-**Response**
+#### Response
 
-```
+```text
 data:["public:phone.wavi@alice","@bob:email.wavi@alice", …]
 ```
 
 A JSON array of strings, on a single line. Empty result is `data:[]`.
 
 The `forAtSign` and `regex` filters operate on key **structure**, not
-value contents — value-level filtering is impossible because the
+value contents, value-level filtering is impossible because the
 server has no plaintext to filter against ([§14](#14-end-to-end-encryption)).
 
 ---
@@ -984,9 +985,9 @@ recipient's atClient via `monitor`.
 
 Emit a notification.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 notify[:id:<id>][:<update|delete>][:messageType:key][:priority:<low|medium|high>][:strategy:<all|latest>][:latestN:<n>][:notifier:<n>][:ttln:<ms>]<metadata>:[public|@<forAtSign>]:<atKey>[@<atSign>][:<value>]
 ```
 
@@ -1004,9 +1005,9 @@ Source: see `at_commons/lib/src/verb/syntax.dart` `notify`.
 | `notifier`        | Identifier of the notifying subsystem. Defaults to `SYSTEM`.                                      |
 | `ttln`            | Notification time-to-live in ms. After expiry the server gives up delivering and marks `expired`. |
 
-**Response** — `data:<notificationId>` on success.
+Response: `data:<notificationId>` on success.
 
-```
+```text
 C: notify:update:ttr:-1:isEncrypted:true:@bob:phone.wavi@alice <ciphertext>\n
 S: data:7c6c8d7d-7e0e-4ab4-9c7d-4b07e1e84a52\n@alice@
 ```
@@ -1017,15 +1018,15 @@ Emit one notification to multiple recipients in one round-trip. The
 recipients are a comma-separated list (no `@` prefix) where the
 single `forAtSign` segment normally goes.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 notify:all:[<update|delete>:][messageType:<key|text>:][ttl:<ms>:][ttb:<ms>:][ttr:<ms>:][ccd:<bool>:]<recipient,recipient,…>:<atKey>[@<atSign>][:<value>]
 ```
 
-**Response** — a JSON map of `recipient → notificationId`:
+Response: a JSON map of `recipient → notificationId`:
 
-```
+```text
 data:{"@bob":"…uuid…","@colin":"…uuid…"}
 ```
 
@@ -1033,21 +1034,21 @@ data:{"@bob":"…uuid…","@colin":"…uuid…"}
 
 List notifications received by the current atSign.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 notify:list[:<fromDate>][:<toDate>][:<regex>]
 ```
 
 Dates are `YYYY-MM-DD`. Source:
 
-```
+```text
 ^notify:list(:(?<fromDate>\d{4}-[01]?\d?-[0123]?\d?))?(:(?<toDate>...))?(:(?<regex>[^:]+))?
 ```
 
-**Response** — JSON array of notification records:
+Response: JSON array of notification records:
 
-```
+```text
 data:[{"id":"…","from":"@bob","to":"@alice","key":"@alice:phone.wavi@bob","value":null,"operation":"update","epochMillis":1603714720965}, …]
 ```
 
@@ -1058,13 +1059,13 @@ to** that atSign instead.
 
 Query the delivery status of a notification by ID.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 notify:status:<notificationId>
 ```
 
-**Response** — `data:<status>` where status is one of:
+Response: `data:<status>` where status is one of:
 
 | Status        | Meaning                                             |
 |---------------|-----------------------------------------------------|
@@ -1078,13 +1079,13 @@ notify:status:<notificationId>
 
 Fetch a full notification record by ID.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 notify:fetch:<notificationId>
 ```
 
-**Response** — `data:<JSON notification record>`. If the notification
+Response: `data:<JSON notification record>`. If the notification
 was expired or never existed, returns
 `data:{"id":"<id>","notificationStatus":"expired"}`.
 
@@ -1094,27 +1095,27 @@ Remove a notification from the local notification log. Note: this is
 log housekeeping; it does **not** send a `notify:delete` to the
 recipient.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 notify:remove:<notificationId>
 ```
 
-**Response** — `data:success`.
+Response: `data:success`.
 
 ### 11.7 `monitor`
 
 Open a long-lived stream of received notifications.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 monitor[:strict][:selfNotifications][:multiplexed][:<epochMillis>][ <regex>]
 ```
 
 Source:
 
-```
+```text
 ^monitor(:strict)?(:selfNotifications)?(:multiplexed)?(:<epochMillis>)?( <regex>)?$
 ```
 
@@ -1126,9 +1127,9 @@ Source:
 | `<epochMillis>`     | Replay notifications received at or after this timestamp.                                           |
 | `<regex>`           | Filter notifications by atKey regex.                                                                |
 
-**Response** — a stream. Each notification arrives as one line:
+Response: a stream. Each notification arrives as one line:
 
-```
+```text
 notification: {"id":"…","from":"@bob","to":"@alice","key":"@alice:phone.wavi@bob",…}
 ```
 
@@ -1147,36 +1148,34 @@ prompt; notifications resume after the response.
 ## 12. The sync verb
 
 `sync:from` walks the commit log of an atServer from a given commit ID
-to the current head, returning the intervening operations. Used both
-by clients (to keep a local cache fresh) and by atServers (to
-synchronise with their cloud counterpart).
+to the current head, returning the intervening operations.
 
 ### 12.1 `sync:from`
 
-**Syntax**
+#### Syntax
 
-```
+```text
 sync:from:<from_commit_seq>[:limit:<n>][:skipDeletesUntil:<n>][:<regex>]
 ```
 
 Source:
 
-```
+```text
 ^sync:from:(?<from_commit_seq>[0-9]+|-1)(:limit:(?<limit>\d+))?(:skipDeletesUntil:(?<skipDeletesUntil>\d+))?(:(?<regex>.+))?$
 ```
 
-- `<from_commit_seq>` — last commit ID the caller has seen. `-1`
+- `<from_commit_seq>`, last commit ID the caller has seen. `-1`
   requests the full commit log from the start.
-- `:limit:<n>` — max entries returned in this round-trip. Caller
+- `:limit:<n>`, max entries returned in this round-trip. Caller
   paginates by repeating with the highest commit ID seen.
-- `:skipDeletesUntil:<n>` — suppress delete operations whose
+- `:skipDeletesUntil:<n>`, suppress delete operations whose
   `commitId <= n`. Used to elide tombstones older than a known sync
   high-water mark.
-- `:<regex>` — filter entries by atKey regex.
+- `:<regex>`, filter entries by atKey regex.
 
-**Response** — JSON array of commit-log entries:
+Response: JSON array of commit-log entries:
 
-```
+```text
 data:[{"atKey":"@bob:phone.wavi@alice","operation":"+","opTime":"2026-05-05T10:30:00.000Z","commitId":42,"value":"<ciphertext>","metadata":{"ttr":-1,"ccd":false,"isEncrypted":true}},
       {"atKey":"@bob:shared_key.wavi@alice","operation":"-","opTime":"2026-05-05T10:31:42.000Z","commitId":43}]
 ```
@@ -1186,7 +1185,7 @@ update.
 
 The legacy `sync:<from_commit_seq>` syntax (without `:from:`) is
 retained for backward compatibility and is documented in
-[Appendix B](#appendix-b--legacy-and-deprecated). New clients must
+[Appendix B](#appendix-b-legacy-and-deprecated). New clients must
 use `sync:from`.
 
 ---
@@ -1198,9 +1197,9 @@ use `sync:from`.
 Manage server-side block lists and configuration parameters. Owner-
 authenticated only.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 config:block:add:@<atSign>[ @<atSign> …]
 config:block:remove:@<atSign>[ @<atSign> …]
 config:block:show
@@ -1209,26 +1208,26 @@ config:reset:<key>
 config:print:<key>
 ```
 
-The block list, once populated, is consulted by `from` — a blocked
+The block list, once populated, is consulted by `from`, a blocked
 atSign receives `error:AT0013-Connection Exception` and the connection
 is closed.
 
-**Response** — `data:success` for mutating operations, `data:[…]` for
+Response: `data:success` for mutating operations, `data:[…]` for
 `show` (a JSON array of blocked atSigns), `data:<value>` for `print`.
 
 ### 13.2 `stats`
 
 Return server statistics.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 stats[:<id>[,<id>…]][:<regex>]
 ```
 
 Source:
 
-```
+```text
 ^stats(?<statId>:((?!0)\d+)?(,(\d+))*)?(:(?<regex>(?<=:3:|:15:).+))?$
 ```
 
@@ -1244,12 +1243,12 @@ by integer IDs:
 | 5  | `topAtSigns`                | `{<atSign>: <hits>, …}` |
 | 6  | `topKeys`                   | `{<atKey>: <hits>, …}`  |
 
-(Servers may expose additional IDs — IDs 11 and 15 take regex filters
+(Servers may expose additional IDs, IDs 11 and 15 take regex filters
 per the syntax; see source for current set.)
 
-**Response**
+#### Response
 
-```
+```text
 data:[{"id":"1","name":"activeInboundConnections","value":"1"},
       {"id":"3","name":"lastCommitId","value":"42"}, …]
 ```
@@ -1258,35 +1257,35 @@ data:[{"id":"1","name":"activeInboundConnections","value":"1"},
 
 Return server runtime information.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 info[:brief|mtls|mtlsbrief]
 ```
 
-**Response shapes**
+#### Response shapes
 
 `info` (full):
 
-```
+```text
 data:{"version":"3.0.28","uptimeAsWords":"1 hours 35 minutes 29 seconds","features":[ {…feature record…}, … ]}
 ```
 
 `info:brief`:
 
-```
+```text
 data:{"version":"3.0.28","uptimeAsMillis":5855295}
 ```
 
 `info:mtls`:
 
-```
+```text
 data:{"mtls_fullchain":"<PEM>"}
 ```
 
 `info:mtlsbrief`:
 
-```
+```text
 data:{"mtls_fullchain_last_modified":"2026-05-05T08:00:00.000Z","mtls_privkey_last_modified":"2026-05-05T08:00:00.000Z"}
 ```
 
@@ -1298,15 +1297,15 @@ deployment.
 Sleep for the given number of milliseconds, then respond. Used as a
 keep-alive / latency probe.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 noop:<delayMillis>
 ```
 
 `<delayMillis>` ≤ 5000.
 
-**Response** — `data:ok` after the delay. Out-of-range values produce
+Response: `data:ok` after the delay. Out-of-range values produce
 `error:AT0022-Exception: noop:<durationInMillis> where the duration
 maximum is 5000 milliseconds`.
 
@@ -1315,18 +1314,18 @@ maximum is 5000 milliseconds`.
 Execute multiple verbs in a single round-trip. Each member of the
 batch is independently parsed and dispatched; failures are per-entry.
 
-**Syntax**
+#### Syntax
 
-```
+```text
 batch:<json-array>
 ```
 
 Where `<json-array>` is `[{"id":<n>,"command":"<verb>"}, …]` and each
 `<verb>` is a single-line verb without the trailing `\n`.
 
-**Response** — array of `{id, response}` pairs in submission order:
+Response: array of `{id, response}` pairs in submission order:
 
-```
+```text
 data:[{"id":1,"response":{"data":"42"}},{"id":2,"response":{"data":"43"}}]
 ```
 
@@ -1337,7 +1336,7 @@ data:[{"id":1,"response":{"data":"42"}},{"id":2,"response":{"data":"43"}}]
 End-to-end encryption is **entirely an atClient concern**. atServers
 store opaque ciphertext in the `value` field, opaque ciphertext in the
 `sharedKeyEnc` metadata field, and opaque metadata about which keys
-encrypted which — but they never see plaintext keys, plaintext values,
+encrypted which, but they never see plaintext keys, plaintext values,
 or have any way to decrypt anything they store. No server-side
 behaviour in this specification depends on understanding what the
 encrypted material means.
@@ -1373,7 +1372,7 @@ accepted for backward compatibility but not recommended.
 Public values may be signed by the owner's signing private key; the
 signature appears in `dataSignature`. Recipients verify against the
 owner's `public:signing_publickey@<owner>`. This is the only signature
-on a value-side payload — encrypted (shared) values rely on the AES
+on a value-side payload, encrypted (shared) values rely on the AES
 authenticated-encryption mode in `encAlgo` to detect tampering.
 
 ### 14.3 Public-key rotation
@@ -1382,7 +1381,7 @@ If the recipient rotates their encryption keypair, every shared key
 encrypted to the old public key becomes unrecoverable. `pubKeyHash`
 lets the recipient detect this on read: if the hash doesn't match
 their current public key, the recipient asks the sender to re-share.
-There is no in-protocol re-key flow; the sender simply re-issues the
+There is no in-protocol re-key flow; the sender re-issues the
 update with a fresh `sharedKeyEnc`.
 
 ### 14.4 Why server-side filtering is impossible
@@ -1394,9 +1393,9 @@ The atServer holds:
 - metadata fields whose meaning it cannot interpret without keys it
   does not have
 
-Any feature requiring the server to reason about plaintext — value-
+Any feature requiring the server to reason about plaintext, value-
 level filters, server-side aggregations over content, content-based
-notifications — is therefore architecturally impossible. This is a
+notifications, is therefore architecturally impossible. This is a
 **security property**, not a performance limitation. Filtering by
 atKey **structure** (regex on the wire-form name) is supported and is
 how `scan`, `notify:list` regexes, and `monitor` filters work.
@@ -1405,12 +1404,16 @@ how `scan`, `notify:list` regexes, and `monitor` filters work.
 
 ## 15. The inter-atServer protocol
 
-When an atClient asks its atServer for cross-atSign data — `lookup`,
+When an atClient asks its atServer for cross-atSign data, `lookup`,
 remote `scan`, or sending a `notify` whose recipient is on a different
-atServer — the atServer **proxies** the request. It opens a TLS
+atServer, the atServer **proxies** the request. It opens a TLS
 connection to the target atServer (resolved via the atDirectory),
 authenticates via the `pol` handshake, and runs the appropriate verb
 on behalf of the requesting client.
+
+The complete set of verbs an atServer ever sends to another atServer
+on this proxied channel is: `from`, `pol`, `lookup`, `plookup`, `scan`,
+and `notify`. Each atServer is the sole authority for its own atSign's data.
 
 This chapter specifies that proxying. The single most important verb
 here is `pol`, the proof-of-life handshake between two atServers.
@@ -1421,7 +1424,7 @@ Source: `at_secondary_server/lib/src/connection/outbound/outbound_client.dart`.
 
 1. Local atServer (call it **A**) needs to talk to remote atServer
    **B**. A's `OutboundClientManager` returns an `OutboundClient`
-   for the target atSign — pooled per-target so repeat traffic to the
+   for the target atSign, pooled per-target so repeat traffic to the
    same B reuses one connection.
 2. **Resolve.** A queries its atDirectory for B's host:port.
 3. **Connect.** A opens a TLS connection to B. Most A→B connections
@@ -1434,7 +1437,7 @@ Source: `at_secondary_server/lib/src/connection/outbound/outbound_client.dart`.
    subsequent encryption-to-B operations cheap and detects key
    rotation early.
 5. **Handshake.** If the planned operation requires authentication, A
-   runs the `pol` handshake — see [§15.2](#152-the-pol-handshake).
+   runs the `pol` handshake, see [§15.2](#152-the-pol-handshake).
    `lookup` requires it; `plookup` does not.
 6. **Run verbs.** A sends the verb (e.g. `lookup:phone.wavi@alice`),
    reads the response, strips the trailing prompt, returns the
@@ -1457,7 +1460,7 @@ public signing key from A and verifying the signature.
 `at_secondary_server/lib/src/verb/handler/pol_verb_handler.dart` and
 `outbound_client.dart::_establishHandShake`.
 
-```
+```text
 A ──TLS──► B  (already connected)
 
 A → B:  from:@A
@@ -1483,7 +1486,7 @@ B's pol handler:
 
 B → A:  @A@
        (verb result inside B is `pol:@A@`; the PolResponseHandler
-        strips the `pol:` prefix, leaving just the prompt-shaped
+        strips the `pol:` prefix, leaving only the prompt-shaped
         confirmation `@A@` on the wire — no separate `data:`
         framing, no trailing `\n@…@`. A's outbound listener
         recognises completion by the `@<currentAtSign>@` shape.)
@@ -1493,12 +1496,12 @@ A:  reads handshake result; if it begins with "@A@", marks the
 ```
 
 After `pol` succeeds, A's connection to B is authenticated **as @A**.
-B treats subsequent verbs on this connection as coming from `@A` — for
+B treats subsequent verbs on this connection as coming from `@A`, for
 example, a `lookup:phone.wavi@A` returns only the keys `@A` is allowed
 to read on B's atServer (`@bob:phone.wavi@A`-shaped, where `@bob` is
 B's atSign).
 
-**Failure modes:**
+#### Failure modes
 
 | Cause                             | Error                                                                                |
 |-----------------------------------|--------------------------------------------------------------------------------------|
@@ -1520,7 +1523,7 @@ atServer:
 3. It sends `lookup:phone.wavi@alice` over the now-authenticated
    outbound connection.
 4. @alice's atServer evaluates the lookup with the inbound connection
-   marked `polAuthenticated as @bob` — the result is whatever @alice
+   marked `polAuthenticated as @bob`, the result is whatever @alice
    has shared **with @bob** (typically `@bob:phone.wavi@alice`).
 5. @alice's atServer responds `data:<value>\n@bob@` (the
    pol-authenticated prompt).
@@ -1539,13 +1542,8 @@ recipient's atServer recognises the inbound connection as
 pol-authenticated and stores the notification in the recipient's
 inbox; the recipient sees it via `monitor`.
 
-### 15.5 Server-to-server `sync:from`
-
-For self-hosted deployments where an atServer pairs with a "cloud"
-mirror (or vice versa), `sync:from` runs over the same
-pol-authenticated outbound connection. Both ends use the same
-commit-log walking protocol described in [§12](#12-the-sync-verb); no
-new verbs are introduced.
+Also relevant: the worked flow in [§16.4](#164-monitor--notify-round-trip)
+shows the full notify→deliver→monitor path end-to-end.
 
 ---
 
@@ -1558,7 +1556,7 @@ atSign, it has only the CRAM secret. It must (a) authenticate, (b)
 generate keypairs, (c) publish the public halves, (d) write the
 private halves to disk.
 
-```
+```text
 C: <TCP+TLS connect to alice's atServer>
 C: from:@alice\n
 S: data:_4af24c03-d732-48f8-a9a2-570e8fb6a01c@alice:d6cac849-9c29-42b0-b0c5-493db62728b9\n@
@@ -1587,10 +1585,10 @@ client now reconnects with `from` + `pkam` for any subsequent session.
 
 ### 16.2 APKAM enrollment end-to-end
 
-Phase 3 — a new app on a new device authenticates as `@alice` without
+Phase 3, a new app on a new device authenticates as `@alice` without
 ever holding the master keys.
 
-```
+```text
 # === New device: generate APKAM keypair, generate APKAM symmetric key,
 #                 RSA-encrypt the APKAM symmetric key to alice's
 #                 public:publickey@alice ===
@@ -1662,7 +1660,7 @@ keys are revocable via `enroll:revoke`.
 @bob looks up `@alice`'s phone number, which `@alice` has shared with
 him.
 
-```
+```text
 # === atClient session as @bob, authenticated to @bob's atServer. ===
 C(bob): lookup:phone.wavi@alice\n
 
@@ -1705,7 +1703,7 @@ phone number.
 
 `@bob` listens for live updates from `@alice`; `@alice` notifies him.
 
-```
+```text
 # === @bob: open monitor session. ===
 C(bob): monitor\n
 # (no immediate response; stream begins.)
@@ -1731,7 +1729,7 @@ S(bob): notification: {"id":"7c6c8d7d-…","from":"@alice","to":"@bob","key":"@b
 
 An atClient that has been offline picks up where it left off.
 
-```
+```text
 # Last seen commit ID: 41.
 C: sync:from:41:limit:100\n
 S: data:[
@@ -1748,7 +1746,7 @@ S: data:[]\n@alice@   # fully caught up.
 Deletes older than the client's `skipDeletesUntil` threshold can be
 elided to compact long sync windows:
 
-```
+```text
 C: sync:from:0:limit:1000:skipDeletesUntil:43\n
 ```
 
@@ -1759,7 +1757,7 @@ C: sync:from:0:limit:1000:skipDeletesUntil:43\n
 Error responses are framed identically to data responses but with the
 prefix `error:` instead of `data:`:
 
-```
+```text
 error:AT0003-Invalid Syntax
 ```
 
@@ -1812,7 +1810,7 @@ should map to an equivalent.
 
 `AT0401` is emitted on **authentication** failure (the credential is
 wrong). `AT0009` is emitted on **authorisation** failure (the
-authenticated principal lacks permission for the requested key —
+authenticated principal lacks permission for the requested key,
 notably APKAM scopes prohibiting the namespace). Implementations must
 distinguish between them; clients may retry on `AT0401` but not on
 `AT0009`.
@@ -1821,46 +1819,45 @@ distinguish between them; clients may retry on `AT0401` but not on
 
 ## 18. Glossary
 
-- **APKAM** — Application PKAM. Per-app, per-device, namespace-scoped
+- **APKAM**, Application PKAM. Per-app, per-device, namespace-scoped
   authentication built on PKAM. The modern way to authenticate.
-- **atClient** — Software acting on behalf of an atSign owner.
-- **atDirectory** — Service mapping atSign → `host:port` of the
+- **atClient**, Software acting on behalf of an atSign owner.
+- **atDirectory**, Service mapping atSign → `host:port` of the
   atSign's atServer.
-- **atKey** — A key in an atServer's keystore. Five shapes (public,
+- **atKey**, A key in an atServer's keystore. Five shapes (public,
   self, shared, local, private) plus augmentations (hidden, cached).
-- **atServer** — The personal server for one atSign.
-- **atSign** — An identifier of the form `@<name>`. Maximum length 55
+- **atServer**, The personal server for one atSign.
+- **atSign**, An identifier of the form `@<name>`. Maximum length 55
   characters.
-- **Commit log** — Append-only log of `update`/`delete` operations.
+- **Commit log**, Append-only log of `update`/`delete` operations.
   Walked by `sync:from`.
-- **CRAM** — Challenge-Response Authentication Mechanism. The
+- **CRAM**, Challenge-Response Authentication Mechanism. The
   bootstrap-only credential, used during onboarding.
-- **Enrollment** — An APKAM record granting an app a namespace-scoped
+- **Enrollment**, An APKAM record granting an app a namespace-scoped
   keypair. Has lifecycle states `pending`, `approved`, `denied`,
   `revoked`, `expired`.
-- **Master AtKeys** — The atSign's root keypairs (PKAM signing,
+- **Master AtKeys**, The atSign's root keypairs (PKAM signing,
   encryption, self-encryption), produced at onboarding.
-- **OTP** — Six-character alphanumeric one-time password. Used to bind
+- **OTP**, Six-character alphanumeric one-time password. Used to bind
   an APKAM enrollment to an out-of-band human approval.
-- **PKAM** — Public-Key Authentication Mechanism. Sign-the-challenge
+- **PKAM**, Public-Key Authentication Mechanism. Sign-the-challenge
   authentication; underpins APKAM.
-- **`pol`** — Proof-of-life. The atServer-to-atServer authentication
+- **`pol`**, Proof-of-life. The atServer-to-atServer authentication
   handshake in which the connecting atServer publishes a signed
   challenge as a public atKey on its own atServer for the receiving
   atServer to fetch and verify.
-- **Prompt** — The trailing `\n@…@` (or `\n@`) that frames the next
+- **Prompt**, The trailing `\n@…@` (or `\n@`) that frames the next
   request on a connection.
-- **`sharedKeyEnc`** — Inline-in-metadata, RSA-encrypted shared
+- **`sharedKeyEnc`**, Inline-in-metadata, RSA-encrypted shared
   symmetric key.
-- **Verb** — A single-line command in the protocol.
+- **Verb**, A single-line command in the protocol.
 
 ---
 
-## Appendix A — Verb reference
+## Appendix A, Verb reference
 
 Terse reference for ctrl-F. Authoritative regex source:
-[
-`at_commons/lib/src/verb/syntax.dart`](https://github.com/atsign-foundation/at_client_sdk/blob/trunk/packages/at_commons/lib/src/verb/syntax.dart).
+[`at_commons/lib/src/verb/syntax.dart`](https://github.com/atsign-foundation/at_client_sdk/blob/trunk/packages/at_commons/lib/src/verb/syntax.dart).
 
 | Verb            | Auth   | Purpose                                                               | Section |
 |-----------------|--------|-----------------------------------------------------------------------|---------|
@@ -1895,7 +1892,7 @@ Terse reference for ctrl-F. Authoritative regex source:
 
 ---
 
-## Appendix B — Legacy and deprecated
+## Appendix B, Legacy and deprecated
 
 The following items remain in the wire grammar for backward
 compatibility but new implementations should not produce them.
@@ -1909,7 +1906,7 @@ post-onboarding entirely.
 
 ### B.2 `sync` (without `:from:`)
 
-```
+```text
 sync:<from_commit_seq>[:<regex>]
 ```
 
@@ -1962,14 +1959,14 @@ should accept it for the foreseeable future.
 
 ---
 
-## Appendix C — Significant near-term projects
+## Appendix C, Significant near-term projects
 
 This appendix lists active workstreams that will materially change
 parts of this specification. Each entry links to the tracking issue;
 issue threads carry the current design state. Implementers should not
 commit to long-lived choices in these areas without checking the
 tracking issues for the present direction. The list is current as of
-2026-05-05; it is not a roadmap commitment, just a snapshot of what is
+2026-05-05; it is not a roadmap commitment, only a snapshot of what is
 moving.
 
 ### C.1 Post-quantum cryptography and crypto agility
@@ -1978,27 +1975,26 @@ The current encryption stack is RSA-2048 (asymmetric) + AES-256
 (symmetric) + SHA-256/SHA-512 (hashing). Transition to post-quantum
 primitives is in active design.
 
-- **Pluggable encryption / decryption schemes** —
-  [at_client_sdk #1891](https://github.com/atsign-foundation/at_client_sdk/issues/1891).
-  Refactor the client encrypt/decrypt path so the algorithm is a
-  pluggable strategy rather than hard-coded RSA + AES. Direction:
-  Signal-style triple-ratchet as the new default. Affects every
-  metadata field that names an algorithm (`encAlgo`, `skeEncAlgo`,
-  `hashingAlgo`).
-- **Implement post-quantum (PQ) cryptography along with crypto
-  agility** —
-  [at_client_sdk #1889](https://github.com/atsign-foundation/at_client_sdk/issues/1889).
-  Land the first PQ primitives behind the pluggable interface above.
-- **Implement post-quantum end-to-end encryption where actors
-  communicate over Atsign Protocol** —
-  [at_client_sdk #1893](https://github.com/atsign-foundation/at_client_sdk/issues/1893).
-  End-to-end PQ encryption on the wire — the protocol-visible part of
-  the PQ work.
+[at_client_sdk #1891](https://github.com/atsign-foundation/at_client_sdk/issues/1891)
+covers **pluggable encryption / decryption schemes**. The plan is to
+refactor the client encrypt/decrypt path so the algorithm is a
+pluggable strategy rather than hard-coded RSA + AES. Direction:
+Signal-style triple-ratchet as the new default. Affects every
+metadata field that names an algorithm (`encAlgo`, `skeEncAlgo`,
+`hashingAlgo`).
+
+[at_client_sdk #1889](https://github.com/atsign-foundation/at_client_sdk/issues/1889)
+covers **post-quantum (PQ) cryptography with crypto agility**, landing
+the first PQ primitives behind the pluggable interface above.
+
+[at_client_sdk #1893](https://github.com/atsign-foundation/at_client_sdk/issues/1893)
+covers **post-quantum end-to-end encryption where actors communicate
+over Atsign Protocol**, the protocol-visible part of the PQ work.
 
 Implementers should treat algorithm names in metadata as
 forward-compatible enums and design for new values appearing.
 
-### C.2 Fast sync ("fsync") — Better sync
+### C.2 Fast sync ("fsync"), Better sync
 
 [at_client_sdk #1894](https://github.com/atsign-foundation/at_client_sdk/issues/1894).
 Replacement for the current commit-log walk-based sync. Targets
@@ -2041,8 +2037,9 @@ this lands it becomes the de-facto compliance gate for an
 "Atsign-Protocol-compliant" implementation; clients of this
 specification should adopt it.
 
-Related: **at_commons tests reflecting at_server / NoPorts usage** —
-[at_client_sdk #1782](https://github.com/atsign-foundation/at_client_sdk/issues/1782).
+Related:
+[at_client_sdk #1782](https://github.com/atsign-foundation/at_client_sdk/issues/1782)
+adds at_commons tests reflecting at_server and NoPorts usage.
 
 ### C.6 Move and improve `at_server_spec` into `at_client_sdk/at_commons`
 
@@ -2055,14 +2052,13 @@ that will remain stable, but related interface paths under
 
 ### C.7 Multi-language SDKs (Java APKAM, others)
 
-- **Java SDK APKAM support** —
-  [operations #348](https://github.com/atsign-foundation/operations/issues/348).
-  The Java SDK is gaining APKAM support, bringing it to parity with
-  the Dart SDK on Phase-3 authentication.
-- **Multi-language support** —
-  [at_client_sdk #1885](https://github.com/atsign-foundation/at_client_sdk/issues/1885).
-  Tracking parent for ports of the SDK to additional languages. This
-  specification document is the basis for those ports.
+[operations #348](https://github.com/atsign-foundation/operations/issues/348)
+adds **APKAM support to the Java SDK**, bringing it to parity with
+the Dart SDK on Phase-3 authentication.
+
+[at_client_sdk #1885](https://github.com/atsign-foundation/at_client_sdk/issues/1885)
+is the tracking parent for **ports of the SDK to additional
+languages**. This specification document is the basis for those ports.
 
 ### C.8 `monitor` immediate-ack response
 
@@ -2094,17 +2090,17 @@ the SDK; not a wire-protocol change.
 [at_server #2568](https://github.com/atsign-foundation/at_server/issues/2568).
 Today, looking up a key whose `eAt` has passed returns `data:null`;
 the proposed correction is `error:AT0015-Key not found`. A small
-change but observable on the wire —
-see [§D.4](#d4-expired-keys-return-null-instead-of-an-at0015-error).
+change but observable on the wire (see
+[§D.4](#d4-expired-keys-return-null-instead-of-an-at0015-error)).
 
 ---
 
-## Appendix D — Inconsistencies and quirks
+## Appendix D, Inconsistencies and quirks
 
 This appendix documents on-the-wire surprises that the per-verb
 sections don't make obvious. Implementers writing a parser, a server,
 or an interoperable client need this list. None of these are
-specification bugs in this document — they are facts about the
+specification bugs in this document, they are facts about the
 deployed protocol that this document accurately describes; they are
 collected here so an implementer can sanity-check failure modes
 against them.
@@ -2113,13 +2109,13 @@ against them.
 
 Both forms appear in current servers:
 
-```
+```text
 error:AT0003-Invalid Syntax
 error:AT0025:Authentication Failed
 ```
 
 The hyphen form predates the colon form; newer error sites tend to
-use `:`. Clients must accept both — splitting only on `-` will fail
+use `:`. Clients must accept both, splitting only on `-` will fail
 on `AT0025`-class errors, splitting only on `:` will misparse
 hyphen-separated messages.
 
@@ -2132,7 +2128,7 @@ will normalise this.
 ### D.2 "Secondary Server" vs "atServer" in error messages
 
 Several error messages still use the old "Secondary Server"
-terminology — e.g. `error:AT0007-Secondary Server not found.` Some
+terminology, e.g. `error:AT0007-Secondary Server not found.` Some
 sites have been updated to "atServer not found"; both wordings are
 emitted in different code paths. Same code (`AT0007`), different
 text. Match on the code, not the message.
@@ -2144,17 +2140,17 @@ See also [Appendix B.6](#b6-commons-and-atserveratsecondary-terminology-drift).
 Most verbs follow `data:<payload>\n@<atSign>@` (or `\n@`
 unauthenticated). A handful do not:
 
-- **`pol`** — emits just `@<atSign>@` with no `data:` prefix and no
+- **`pol`**, emits just `@<atSign>@` with no `data:` prefix and no
   trailing `\n@…@` framing. The `PolResponseHandler` strips the
   `pol:` prefix from the verb's internal result. Outbound clients
   detect "pol succeeded" by matching the wire shape `<currentAtSign>@`.
-- **`monitor`** — emits a stream of `notification: {<json>}\n` lines
+- **`monitor`**, emits a stream of `notification: {<json>}\n` lines
   with no per-line `data:` prefix and no trailing prompt between
   events. Connection remains open until either side closes.
-- **`stream`** — uses binary framing with `stream:ack` / `stream:done`
+- **`stream`**, uses binary framing with `stream:ack` / `stream:done`
   control lines interleaved with raw payload bytes. (`stream` is
   legacy, see Appendix B.5.)
-- **`from`** — see [§D.6](#d6-from-response-shape-self-vs-cross).
+- **`from`**, see [§D.6](#d6-from-response-shape-self-vs-cross).
 
 ### D.4 Expired keys return null instead of an AT0015 error
 
@@ -2162,8 +2158,8 @@ A `lookup` against an expired key returns `data:null` rather than
 `error:AT0015-Key not found`. This conflicts with the documented
 behaviour of `KeyNotFoundException` and surprises clients that switch
 on the error path. Tracked in
-[at_server #2568](https://github.com/atsign-foundation/at_server/issues/2568)
-— the proposed fix is to emit `AT0015` consistently. Until then,
+[at_server #2568](https://github.com/atsign-foundation/at_server/issues/2568);
+the proposed fix is to emit `AT0015` consistently. Until then,
 clients reading possibly-expired keys must handle `data:null` as a
 not-found indicator.
 
@@ -2185,18 +2181,18 @@ surprised when they switch authentication contexts.
 
 For a self-connect, the `from` response payload is
 
-```
+```text
 data:<sessionId><atSign>:<proof>
 ```
 
 For a cross-atSign connect, it is
 
-```
+```text
 data:proof:<sessionId>@<atSign>:<proof>
 ```
 
 The `proof:` infix is the difference. The `FromResponseHandler`
-prepends `data:` only when the verb result starts with `proof:` — the
+prepends `data:` only when the verb result starts with `proof:`, the
 self-connect handler emits a string already prefixed `data:`, so
 there is no double-prefixing. Parsers must not assume a uniform
 "`data:` then payload" shape for `from`.
@@ -2208,7 +2204,7 @@ written to the commit log. Rather than return a real commit ID, the
 handler returns the sentinel `-1`. Clients must not interpret this
 as an error.
 
-### D.8 Mutating verbs typically require auth — `enroll:request` does not
+### D.8 Mutating verbs typically require auth, `enroll:request` does not
 
 `enroll:request` is a mutating verb (it creates a pending enrollment
 record on the server) but it can be sent on an **unauthenticated**
@@ -2230,7 +2226,7 @@ it is applied **only to plaintext public values** by the atServer.
   specific; do not rely on either path.
 
 Because `\n` is the framing terminator, a client must never write a
-plaintext value containing an unescaped `\n` — the server will treat
+plaintext value containing an unescaped `\n`, the server will treat
 the `\n` as end-of-command.
 
 ### D.10 atDirectory historically emits `\r\n@`
@@ -2285,7 +2281,7 @@ first and fall back if rejected.
 `pubKeyCS` (a checksum) was the predecessor of `pubKeyHash` (a hash
 plus `hashingAlgo` companion field). Servers accept both on read.
 New writes must emit `pubKeyHash` + `hashingAlgo`. A record may
-carry one or the other, never both meaningfully — see Appendix B.4.
+carry one or the other, never both meaningfully, see Appendix B.4.
 
 ### D.17 Session ID format
 

--- a/specification/atsign_protocol_specification.old.md
+++ b/specification/atsign_protocol_specification.old.md
@@ -1,5 +1,8 @@
 # Atsign Protocol Specification
 
+<!-- pyml disable-num-lines 2000 md046-->
+<!-- pyml disable-num-lines 2000 md007-->
+
 | **Subject**   | Atsign Protocol specification                      |
 |---------------|----------------------------------------------------|
 | **Author(s)** | Colin Constable, Kevin Nickels, Jagannadh Vanghuri |
@@ -51,17 +54,16 @@ characters (UTF-8) excluding "@", ":" and a white space (" "). A key in an
 atServer can be any of the following 5 types:
 
 1. Public Key
-
     - A public key is a key which can be looked up by any atSign owner.
     - A public key should be part of the _scan_ verb result.
     - Format of the public key should be `public:<key><atSign>`.
 
-   **Example:**
+    **Example:**
 
-   `public:location@alice`
+    `public:location@alice`
 
-   > The owner of the atServer should be allowed to update or delete the value
-   > of a public key.
+   >      The owner of the atServer should be allowed to update or delete the value
+   >      of a public key.
 
 2. Self Key
 

--- a/specification/atsign_protocol_specification.old.md
+++ b/specification/atsign_protocol_specification.old.md
@@ -12,8 +12,8 @@
 The atDirectory provides a lookup of where an atServer for an atsign is running.
 This is similar to a DNS server.
 
-When asking an atDirectory for the lookup of a particular atSign, the 
-atDirectory should respond with fqdn:port of the atServer, or `null` if the 
+When asking an atDirectory for the lookup of a particular atSign, the
+atDirectory should respond with fqdn:port of the atServer, or `null` if the
 atSign does not exist.
 
 **Response:**
@@ -52,9 +52,9 @@ atServer can be any of the following 5 types:
 
 1. Public Key
 
-   - A public key is a key which can be looked up by any atSign owner.
-   - A public key should be part of the _scan_ verb result.
-   - Format of the public key should be `public:<key><atSign>`.
+    - A public key is a key which can be looked up by any atSign owner.
+    - A public key should be part of the _scan_ verb result.
+    - Format of the public key should be `public:<key><atSign>`.
 
    **Example:**
 
@@ -65,10 +65,10 @@ atServer can be any of the following 5 types:
 
 2. Self Key
 
-   - A self key is a key which cannot be looked up any atSign user other than
-     the one who created it.
-   - A self key should be part of the _scan_ verb result.
-   - Format of the self key should be `<key><atSign>`.
+    - A self key is a key which cannot be looked up any atSign user other than
+      the one who created it.
+    - A self key should be part of the _scan_ verb result.
+    - Format of the self key should be `<key><atSign>`.
 
    **Example:**
 
@@ -79,12 +79,13 @@ atServer can be any of the following 5 types:
 
 3. Shared key
 
-   - A shared key can only be looked up by an atSign owner with whom the data
-     has been shared.
-   - A shared key should be part of the _scan_ verb result only for the user who
-     created it and the specific user it has been shared with.
-   - Format of the key shared with someone else should be
-     `<sharedWith atSign>:<key><createdBy atSign>`
+    - A shared key can only be looked up by an atSign owner with whom the data
+      has been shared.
+    - A shared key should be part of the _scan_ verb result only for the user
+      who
+      created it and the specific user it has been shared with.
+    - Format of the key shared with someone else should be
+      `<sharedWith atSign>:<key><createdBy atSign>`
 
    **Example:**
 
@@ -103,9 +104,9 @@ key types.
 
    > Public, self, or shared key can be hidden.
 
-   - Format of the hidden key should follow its primary type's format, but
-     `<key>` must start with an underscore (`_`).
-   - A hidden key should **not** be part of the _scan_ verb result.
+    - Format of the hidden key should follow its primary type's format, but
+      `<key>` must start with an underscore (`_`).
+    - A hidden key should **not** be part of the _scan_ verb result.
 
    **Examples:**
 
@@ -119,13 +120,14 @@ key types.
 
    > Only shared keys should be cached.
 
-   - A cached key is a key that was originally created by another atSign user
-     but is now cached on the atServer of another user's atSign as he/she was
-     given permission to cache it.
-   - A cached key should be listed in the _scan_ verb result for the atSign user
-     who cached it.
-   - Format of the key shared with someone else should be
-     `cached:<sharedWith atSign>:<key>:<createdBy atSign>`
+    - A cached key is a key that was originally created by another atSign user
+      but is now cached on the atServer of another user's atSign as he/she was
+      given permission to cache it.
+    - A cached key should be listed in the _scan_ verb result for the atSign
+      user
+      who cached it.
+    - Format of the key shared with someone else should be
+      `cached:<sharedWith atSign>:<key>:<createdBy atSign>`
 
    **Example:**
 
@@ -515,7 +517,7 @@ minutes.
 `update:ttl:600000:location@bob bob's location value but key expires in 10 minutes`
 
 Put a shared key/value pair into the atServer with key @alice:phone@bob (shared
-with @alice and shared by @bob) with value `@bob`'s phone number shared to 
+with @alice and shared by @bob) with value `@bob`'s phone number shared to
 @alice.
 
 `update:@alice:phone@bob bob's phone number shared to @alice`
@@ -654,25 +656,25 @@ shared by `@alice` and shared with you).
 ```json
 data:
 {
-    "createdBy":"@bob",
-    "updatedBy":"@bob",
-    "createdAt":"2020-10-21 09:46:48.982Z",
-    "updatedAt":"2020-10-21 09:46:48.982Z",
-    "availableAt":"null",
-    "expiresAt":"null",
-    "refreshAt":"2020-10-21 09:46:58.982Z",
-    "status":"active",
-    "version":0,
-    "ttl":null,
-    "ttb":null,
-    "ttr":10000,
-    "ccd":false,
-    "isBinary":false,
-    "isEncrypted":false
- }
+"createdBy": "@bob",
+"updatedBy": "@bob",
+"createdAt":"2020-10-21 09:46:48.982Z",
+"updatedAt": "2020-10-21 09:46:48.982Z",
+"availableAt": "null",
+"expiresAt": "null",
+"refreshAt": "2020-10-21 09:46:58.982Z",
+"status":"active",
+"version": 0,
+"ttl": null,
+"ttb": null,
+"ttr": 10000,
+"ccd":false,
+"isBinary": false,
+"isEncrypted": false
+}
 ```
 
-If the operation is to look up the metadata and the data together then the 
+If the operation is to look up the metadata and the data together then the
 result should be wrapped in a JSON in the following format:
 
 `data:<Value and Metadata in a JSON>`
@@ -680,26 +682,26 @@ result should be wrapped in a JSON in the following format:
 ```json
 data:
 {
-    "key":"@alice:country@bob",
-    "data":"USA",
-    "metaData":
-    {
-        "createdBy":"@bob",
-        "updatedBy":"@bob",
-        "createdAt":"2020-10-21 09:46:48.982Z",
-        "updatedAt":"2020-10-21 09:46:48.982Z",
-        "availableAt":"null",
-        "expiresAt":"null",
-        "refreshAt":"2020-10-21 09:46:58.982Z",
-        "status":"active",
-        "version":0,
-        "ttl":null,
-        "ttb":null,
-        "ttr":10000,
-        "ccd":false,
-        "isBinary":false,
-        "isEncrypted":false
-    }
+"key": "@alice:country@bob",
+"data": "USA",
+"metaData":
+{
+"createdBy": "@bob",
+"updatedBy": "@bob",
+"createdAt":"2020-10-21 09:46:48.982Z",
+"updatedAt": "2020-10-21 09:46:48.982Z",
+"availableAt": "null",
+"expiresAt": "null",
+"refreshAt": "2020-10-21 09:46:58.982Z",
+"status":"active",
+"version": 0,
+"ttl": null,
+"ttb": null,
+"ttr": 10000,
+"ccd":false,
+"isBinary": false,
+"isEncrypted": false
+}
 }
 ```
 
@@ -946,8 +948,9 @@ which returns all the commit entries.
 <!-- pyml disable-num-lines 4 md013-->
 
 ```json
-data:[{"atKey":"@bob:phone@alice","operation":"+","opTime":"2020-10-26 11:57:43.732","commitId":0,"value":"12345","metadata":{"ttr":"36000000","ccd":"false"}},
-{"atKey":"@bob:shared_key@alice","operation":"-","opTime":"2020-10-26 09:44:54.382219Z","commitId":1}]
+data:[{"atKey": "@bob:phone@alice", "operation": "+", "opTime":"2020-10-26 11:57:43.732", "commitId": 0, "value": "12345","metadata":{"ttr": "36000000", "ccd": "false"}},
+{"atKey": "@bob:shared_key@alice", "operation": "-", "opTime":"2020-10-26 09:44:54.382219Z", "commitId": 1}
+]
 ```
 
 ### Notification Verbs
@@ -973,7 +976,7 @@ notify:((?<operation>update|delete):)?(ttl:(?<ttl>\d+):)?(ttb:(?<ttb>\d+):)?(ttr
 <!-- pyml disable-num-lines 3 md013-->
 
 ```json
-notify:update:ttr:-1:@{RECIPIENT}:{KEY}.{NAMESPACE}@{SENDER}:{BASE64ENCODED_CYPHERTEXT}
+notify:update: ttr: -1: @{RECIPIENT}:{KEY}.{NAMESPACE}@{SENDER}:{BASE64ENCODED_CYPHERTEXT}
 ```
 
 **Example:**
@@ -1118,6 +1121,7 @@ Following is the regex
 **Response:**
 
 <!-- pyml disable-num-lines 3 md013-->
+
 ```text
 data: {id: e8213024-ea78-475b-a8a7-d2ccc9fa5939, fromAtSign: @alice, notificationDateTime: 2025-01-10 10:08:44.090Z, toAtSign: @bob, notification: @bob:shared_key@alice, type: NotificationType.sent, opType: OperationType.update, messageType: MessageType.key, priority: NotificationPriority.low, notificationStatus: NotificationStatus.queued, retryCount: 1, strategy: all, depth: 1, notifier: SYSTEM, expiresAt: 2025-01-10 10:23:44.092Z, atValue: null, atMetadata: {createdBy: @alice, ttl: 0, ttb: 0, isEncrypted: true}, ttl: 900000}
 ```
@@ -1133,6 +1137,7 @@ The "notify:all" allows to notify multiple @sign's at the same time.
 Following is the regex
 
 <!-- pyml disable-num-lines 3 md013-->
+
 ```text
 notify:all:((?<operation>update|delete):)?(messageType:((?<messageType>key|text):))?(?:ttl:(?<ttl>\d+):)?(?:ttb:(?<ttb>\d+):)?(?:ttr:(?<ttr>-?\d+):)?(?:ccd:(?<ccd>true|false+):)?(?<forAtSign>(([^:\s])+)?(,([^:\s]+))*)(:(?<atKey>[^@:\s]+))(@(?<atSign>[^@:\s]+))?(:(?<value>.+))?$
 ```
@@ -1144,15 +1149,20 @@ notify:all:((?<operation>update|delete):)?(messageType:((?<messageType>key|text)
 **Response:**
 
 <!-- pyml disable-num-lines 3 md013-->
+
 ```json
-{"@bob":"444504a3-aa47-478d-93ec-3113f69a9230","@colin":"31b35469-2836-431a-b988-353bb9785686"}, _type: null, _isError: false, _errorMessage: null}
+{
+  "@bob": "444504a3-aa47-478d-93ec-3113f69a9230",
+  "@colin": "31b35469-2836-431a-b988-353bb9785686"
+}, _type: null, _isError: false, _errorMessage: null
+}
 ```
 
 **Description:**
 
 The verb allows to notify multiple @sign's at the same time.
 The client should be authenticated to the server prior to using the notify verb.
-To notify a key use messageType:key. To notify a message use  messageType:text.
+To notify a key use messageType:key. To notify a message use messageType:text.
 
 #### The `monitor` Verb
 
@@ -1180,7 +1190,7 @@ Returns a stream of notifications.
 
 ```json
 @alice@monitor
-notification: {"id":"773e226d-dac2-4269-b1ee-64d7ce93a42f","from":"@bob","to":"@alice","key":"@alice:phone@bob","value":null,"operation":"update","epochMillis":1603714720965}
+notification: {"id": "773e226d-dac2-4269-b1ee-64d7ce93a42f", "from": "@bob", "to":"@alice", "key": "@alice:phone@bob", "value": null,"operation": "update", "epochMillis": 1603714720965}
 ```
 
 **Description:**
@@ -1209,6 +1219,7 @@ The `enroll` verb can be used to submit an APKAM enrollment.
 Regex for enroll verb
 
 <!-- pyml disable-num-lines 3 md013-->
+
 ```text
 enroll:(?<operation>(?:(request|approve|deny|revoke|list|fetch|unrevoke|delete)))(:(?<force>force))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$
 ```
@@ -1218,6 +1229,7 @@ enroll:(?<operation>(?:(request|approve|deny|revoke|list|fetch|unrevoke|delete))
 Submit an enrollment:
 
 <!-- pyml disable-num-lines 3 md013-->
+
 ```text
 enroll:request:{"appName":"wavi","deviceName":"iphone","namespaces":{"wavi":"rw"},"otp":"<otp>","apkamPublicKey":"<apkamPublicKey>","encryptedAPKAMSymmetricKey": "<encryptedAPKAMSymmetricKey>"}
 ```
@@ -1231,6 +1243,7 @@ data:{"enrollmentId":<enrollmentId>, "status": "pending"}
 Approve an enrollment:
 
 <!-- pyml disable-num-lines 3 md013-->
+
 ```text
 enroll:approve:{"enrollmentId":<enrollmentId>,"encryptedDefaultEncryptionPrivateKey":<encryptedDefaultEncryptionPrivateKey>,"encPrivateKeyIV":"<encryptionPrivateKeyIV>","encryptedDefaultSelfEncryptionKey": "<encryptedDefaultSelfEncryptionKey>","selfEncKeyIV":"<selfEncryptionKeyIV>"}
 ```
@@ -1272,8 +1285,17 @@ enroll:fetch:{"enrollmentId":<enrollmentId>}
 ```
 
 <!-- pyml disable-num-lines 3 md013-->
+
 ```json
-{"appName": "wavi", "deviceName": "iphone", "namespace": {"wavi": "rw"}, "encryptedAPKAMSymmetricKey": "dummy_apkam_key", "status": "approved"}
+{
+  "appName": "wavi",
+  "deviceName": "iphone",
+  "namespace": {
+    "wavi": "rw"
+  },
+  "encryptedAPKAMSymmetricKey": "dummy_apkam_key",
+  "status": "approved"
+}
 ```
 
 List enrollments:
@@ -1283,8 +1305,26 @@ enroll:list
 ```
 
 <!-- pyml disable-num-lines 3 md013-->
+
 ```json
-{"_data": {"9358e00b-a4f9-4c8f-ac16-bfe31f91b201.new.enrollments.__manage@alice":{"appName":"wavi","deviceName":"mydevice","namespace":{"wavi":"r","__manage":"rw","*":"rw"},"encryptedAPKAMSymmetricKey":null,"status":"approved"}}, "_type": null, "_isError": false, "_errorMessage": null}
+{
+  "_data": {
+    "9358e00b-a4f9-4c8f-ac16-bfe31f91b201.new.enrollments.__manage@alice": {
+      "appName": "wavi",
+      "deviceName": "mydevice",
+      "namespace": {
+        "wavi": "r",
+        "__manage": "rw",
+        "*": "rw"
+      },
+      "encryptedAPKAMSymmetricKey": null,
+      "status": "approved"
+    }
+  },
+  "_type": null,
+  "_isError": false,
+  "_errorMessage": null
+}
 ```
 
 **Description:**
@@ -1296,22 +1336,31 @@ The enrolled app which receives the notification may approve or
 reject the enrollment request.
 
 <!-- pyml disable-num-lines 3 md013-->
-| Option                         | Required | Description                                                       |
-|--------------------------------|----------|-------------------------------------------------------------------|
+
+| Option | Required | Description |
+|--------|----------|-------------|
+
 <!-- pyml disable-num-lines 3 md013-->
-| `<operation>`                  | Yes      | Name of the enroll operation e.g. approve, request,deny etc., |
+| `<operation>`                  | Yes | Name of the enroll operation e.g.
+approve, request,deny etc., |
 <!-- pyml disable-num-lines 3 md013-->
-| `<deviceName>`                 | No       | Unique identifier of the device requesting enrollment             |
+| `<deviceName>`                 | No | Unique identifier of the device
+requesting enrollment |
 <!-- pyml disable-num-lines 3 md013-->
-| `<appName>`                    | No       | Name of the app or client requesting enrollment                   |
+| `<appName>`                    | No | Name of the app or client requesting
+enrollment |
 <!-- pyml disable-num-lines 3 md013-->
-| `<namespaces>`                 | No       | List of namespaces that a requesting client/app needs access to   |
+| `<namespaces>`                 | No | List of namespaces that a requesting
+client/app needs access to |
 <!-- pyml disable-num-lines 3 md013-->
-| `<otp>`                        | No       | One time passcode fetched using otp verb                          |
+| `<otp>`                        | No | One time passcode fetched using otp
+verb |
 <!-- pyml disable-num-lines 3 md013-->
-| `<apkamPublicKey>`             | No       | Public key from an asymmetric key pair for the current enrollment |
+| `<apkamPublicKey>`             | No | Public key from an asymmetric key pair
+for the current enrollment |
 <!-- pyml disable-num-lines 3 md013-->
-| `<encryptedAPKAMSymmetricKey>` | No       | APKAM symmetric key encrypted with APKAM public key               |
+| `<encryptedAPKAMSymmetricKey>` | No | APKAM symmetric key encrypted with APKAM
+public key |
 
 #### The `otp` verb
 
@@ -1377,6 +1426,7 @@ the secondary keystore.
 Regex for keys verb
 
 <!-- pyml disable-num-lines 3 md013-->
+
 ```text
 keys:((?<operation>put|get|delete):?)(?:(?<visibility>public|private|self):?)?(?:namespace:(?<namespace>[a-zA-Z0-9_]+):?)?(?:appName:(?<appName>[a-zA-Z0-9_]+):?)?(?:deviceName:(?<deviceName>[a-zA-Z0-9_]+):?)?(?:keyType:(?<keyType>[a-zA-Z0-9_-]+):?)?'(?:encryptionKeyName:(?<encryptionKeyName>[a-zA-Z0-9_\-]+):?)?(?:keyName:(?<keyName>\S+) ?)?(?<keyValue>.*)?$
 ```
@@ -1386,6 +1436,7 @@ keys:((?<operation>put|get|delete):?)(?:(?<visibility>public|private|self):?)?(?
 Put an encryption public key
 
 <!-- pyml disable-num-lines 3 md013-->
+
 ```text
 keys:put:public:namespace:__global:keyType:rsa2048:keyName:encryption_<enrollmentId> <rsa_public_key>
 ```
@@ -1399,6 +1450,7 @@ data:-1
 Put a symmetric AES key which is encrypted with encryption public key
 
 <!-- pyml disable-num-lines 3 md013-->
+
 ```text
 keys:put:self:namespace:__global:appName:wavi:deviceName:iphone:keyType:aes256:encryptionKeyName:encryption_<enrollmentId>:keyName:myAESkey <encryptedAESKey>
 ```
@@ -1418,6 +1470,7 @@ keys:get:keyName:public:encryption_<enrollmentId>.__public_keys.__global@alice
 Response
 
 <!-- pyml disable-num-lines 3 md013-->
+
 ```text
 data: {"enrollmentId":<enrollmentId>, "keyType":rsa2048, "value":  <rsa_public_key>}
 ```
@@ -1442,6 +1495,7 @@ batch:(?<json>.+)$
 Send an update and delete:
 
 <!-- pyml disable-num-lines 3 md013-->
+
 ```text
 batch:[{"id":1, "commmand":"update:location@alice newyork"},{"id":2, "commmand":"delete:location@alice"}]
 ```
@@ -1492,7 +1546,8 @@ Individual statistics can be retrieved using the respective Id.
 
 ```json
 @alice@stats:1
-data: [{"id":"1","name":"activeInboundConnections","value":"1"}]
+data: [{"id": "1", "name": "activeInboundConnections", "value":"1"}
+]
 ```
 
 #### The `info` Verb
@@ -1510,13 +1565,13 @@ Regex: `^info(:brief)?$`
 <!-- pyml disable-num-lines 3 md013-->
 
 ```json
-data:{"version":"3.0.28","uptimeAsWords":"1 hours 35 minutes 29 seconds","features":[{"name":"noop:","status":"Beta","description":"The No-Op verb simply does nothing for the requested number of milliseconds. The requested number of milliseconds may not be greater than 5000. Upon completion, the noop verb sends 'ok' as a response to the client.","syntax":"^noop:(?<delayMillis>\\d+)$"},{"name":"info:","status":"Beta","description":"The Info verb returns some information about the server including uptime and some info about available features. ","syntax":"^info(:brief)?$"}]}
+data:{"version": "3.0.28", "uptimeAsWords": "1 hours 35 minutes 29 seconds", "features":[{"name": "noop:", "status": "Beta", "description":"The No-Op verb simply does nothing for the requested number of milliseconds. The requested number of milliseconds may not be greater than 5000. Upon completion, the noop verb sends 'ok' as a response to the client.", "syntax": "^noop:(?<delayMillis>\\d+)$"},{"name": "info:", "status": "Beta", "description":"The Info verb returns some information about the server including uptime and some info about available features. ", "syntax": "^info(:brief)?$"}]}
 ```
 
 `info:brief`
 
 ```json
-data:{"version":"3.0.28","uptimeAsMillis":5855295}
+data:{"version": "3.0.28", "uptimeAsMillis": 5855295}
 ```
 
 #### The `noop` Verb

--- a/specification/atsign_protocol_specification.old.md
+++ b/specification/atsign_protocol_specification.old.md
@@ -1,7 +1,7 @@
-# atProtocol Specification
+# Atsign Protocol Specification
 
-| **Subject**   | atProtocol specification                           |
-| ------------- | -------------------------------------------------- |
+| **Subject**   | Atsign Protocol specification                      |
+|---------------|----------------------------------------------------|
 | **Author(s)** | Colin Constable, Kevin Nickels, Jagannadh Vanghuri |
 |               | Gary Casey, Chris Swan, Xavier Chanthavong         |
 | **Revision**  | v1.0.0 (draft)                                     |
@@ -12,10 +12,9 @@
 The atDirectory provides a lookup of where an atServer for an atsign is running.
 This is similar to a DNS server.
 
-When asking an atDirectory for the lookup of a particular atSign the atDirectory
-should respond with a null if the name does not exist and if the name exists the
-DNS name or address of the atServer and the IP port number for that atSign
-should be returned.
+When asking an atDirectory for the lookup of a particular atSign, the 
+atDirectory should respond with fqdn:port of the atServer, or `null` if the 
+atSign does not exist.
 
 **Response:**
 
@@ -29,7 +28,7 @@ to be lookup requests.
 An atServer is where an atSign user's personal data should be stored. One
 interacts with an atServer using the verbs exposed by the protocol.
 
-An atServer should have 4 major sub components:
+An atServer should have 4 major subcomponents:
 
 1. Key Store
 2. Commit Log
@@ -37,7 +36,7 @@ An atServer should have 4 major sub components:
 4. Notification Log
 
 Verbs described in the document should be used to create, update, delete, and
-retrieve information from the above sub components.
+retrieve information from the above subcomponents.
 
 ### 1. Key Store
 
@@ -47,7 +46,7 @@ metadata for a key.
 
 #### Key
 
-A key in the atProtocol can be formed by using any alphanumeric and special
+A key in the Atsign Protocol can be formed by using any alphanumeric and special
 characters (UTF-8) excluding "@", ":" and a white space (" "). A key in an
 atServer can be any of the following 5 types:
 
@@ -170,7 +169,7 @@ inserted.
 <!--pyml disable-num-lines 17 md013-->
 
 | **Meta Attribute** | **Auto create?** | **Description**                                                                                                                |
-| ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+|--------------------|------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | createdOn          | Yes              | Date and time when the key has been created.                                                                                   |
 | createdBy          | Yes              | atSign that has created the key                                                                                                |
 | updatedOn          | Yes              | Date and time when the key has been last updated.                                                                              |
@@ -190,7 +189,7 @@ inserted.
 
 An atServer should record any create, update and delete operations in a commit
 log. The Commit Log should record these operations with a unique commit id so
-that users of the atServer can lookup operations that happened on or after a
+that users of the atServer can look up operations that happened on or after a
 given commit id.
 
 An atServer should provide a way to compact the Commit Log based on time and
@@ -224,7 +223,7 @@ An atServer should honor the following configuration parameters.
 <!-- pyml disable-num-lines 9 md013-->
 
 | **Key**                       | **Valid Values**     | **Description**                                                                                                                                                       |
-| ----------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------------------------------|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **autoNotify**                | true/false           | If set to true, an atServer should automatically notify another atSign user when a key has been shared with them. Please refer to the _notify_ verb spec for details. |
 | **bufferLimit**               | Number of bytes      | Maximum size of a value for a key that can be transferred to an atServer                                                                                              |
 | **inbound_max_limit**         | An Integer           | Maximum number of inbound connections that an atServer can accept                                                                                                     |
@@ -246,7 +245,7 @@ An atServer should have the following standard keys:
 <!-- pyml disable-num-lines 19 md013-->
 
 | **Key**                   | **Description**                                               |
-| ------------------------- | ------------------------------------------------------------- |
+|---------------------------|---------------------------------------------------------------|
 | public:publickey@         | Public key used by other atSigns for encryption.              |
 | public:signing_publickey@ | Public key used on a pol handler to verify a signed challenge |
 | @signing_privatekey@      | Private key used to sign a challenge on a pol request         |
@@ -311,7 +310,7 @@ The `from` verb is used to tell the atServer what atSign you claim to be. With
 the `from` verb, one can connect to one's own atServer or someone else's
 atServer. In both cases, the atServer responds back with a challenge to prove
 that you are who you claim to be. This is part of the authentication mechanism
-of the atProtocol.
+of the Atsign Protocol.
 
 This authentication mechanism varies based on whether you are connecting to your
 own atServer (cram) or someone else's atServer (pol).
@@ -319,7 +318,7 @@ own atServer (cram) or someone else's atServer (pol).
 **Options:**
 
 | Option    | Required | Description                       |
-| --------- | -------- | --------------------------------- |
+|-----------|----------|-----------------------------------|
 | `<@sign>` | Yes      | The atSign you are claiming to be |
 
 Required: Yes
@@ -368,7 +367,7 @@ connect to the atServer and changes the prompt to your atSign.
 **Options:**
 
 | Option     | Required | Description         |
-| ---------- | -------- | ------------------- |
+|------------|----------|---------------------|
 | `<digest>` | Yes      | encrypted challenge |
 
 #### The `pkam` verb
@@ -409,7 +408,7 @@ your atSign.
 **Options:**
 
 | Option     | Required | Description         |
-| ---------- | -------- | ------------------- |
+|------------|----------|---------------------|
 | `<digest>` | Yes      | encrypted challenge |
 
 #### The `pol` verb
@@ -441,7 +440,7 @@ the following error and close the connection to the server.
 **Description:**
 
 The `pol` verb follows the `from` verb. 'pol' indicates another atServer that
-the user who is trying to connect is ready to authenticate themself. For
+the user who is trying to connect is ready to authenticate themselves. For
 example, if @bob is trying to connect to @alice, @bob would take the key and
 value from the proof response of the verb and create a public key and value
 which then can be looked up by @alice. After @alice looks up @bob's atServer
@@ -474,7 +473,7 @@ Following regex represents the syntax of the `scan` verb:
 **Description:**
 
 The atServer should return the keys within the atServer if the scan verb
-executed succesfully.
+executed successfully.
 
 The atServer will respond accordingly to whether the atSign is authenticated or
 not.
@@ -482,7 +481,7 @@ not.
 **Options:**
 
 | Option         | Required | Description                                |
-| -------------- | -------- | ------------------------------------------ |
+|----------------|----------|--------------------------------------------|
 | `<showhidden`> | No       | If true, will show hidden internal keys    |
 | `<forAtSign>`  | No       | Filter keys that are created by the atSign |
 
@@ -503,20 +502,21 @@ Following regex represents the syntax of the `update` verb:
 
 **Example:**
 
-Put a key/value pair into the atServer with key location@bob and value bob's
+Put a key/value pair into the atServer with key location@bob and value `@bob`'s
 location value. This operation will create a new key if it does not already
 exist. If it already exists, it will overwrite the existing value.
 
 `update:location@bob bob's location value`
 
-Put a key/value pair into the atServer with key location@bob and value bob's
+Put a key/value pair into the atServer with key location@bob and value `@bob`'s
 location value but key expires in 10 minutes. The time to live of this key is 10
 minutes.
 
 `update:ttl:600000:location@bob bob's location value but key expires in 10 minutes`
 
 Put a shared key/value pair into the atServer with key @alice:phone@bob (shared
-with @alice and shared by @bob) with value bob's phone number shared to @alice.
+with @alice and shared by @bob) with value `@bob`'s phone number shared to 
+@alice.
 
 `update:@alice:phone@bob bob's phone number shared to @alice`
 
@@ -536,7 +536,7 @@ following error and close the connection to the server.
 
 The `update` verb should be used to perform create/update operations on the
 atServer. The `update` verb requires the owner of the atServer to authenticate
-themself to the atServer using `from` and `cram` verbs.
+themselves to the atServer using `from` and `cram` verbs.
 
 If a key has been created for another atSign user, the atServer should honor
 "autoNotify" configuration parameter.
@@ -546,7 +546,7 @@ If a key has been created for another atSign user, the atServer should honor
 <!-- pyml disable-num-lines 10 md013-->
 
 | Option       | Required                                                      | Description                                                                                                                                                                                     |
-| ------------ | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|--------------|---------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `<ttl>`      | No                                                            | Time to live in milliseconds                                                                                                                                                                    |
 | `<ttb>`      | No                                                            | Time to birth in milliseconds                                                                                                                                                                   |
 | `<ttr>`      | No                                                            | Time to refresh in milliseconds. ttr > -1 is a valid value which indicates that the user with whom the key has been shared can keep it forever and the value for this key won't change forever. |
@@ -599,7 +599,7 @@ with the following error and close the connection to the server
 
 The `update:meta` verb should be used to perform create/update operations on the
 atServer. The `update:meta` verb requires the owner of the atServer to
-authenticate themself to the atServer using `from` and `cram` verbs.
+authenticate themselves to the atServer using `from` and `cram` verbs.
 
 The atServer should allow creation of keys with null values. If a key has been
 created for another atSign user, the atServer should honor "autoNotify"
@@ -610,7 +610,7 @@ configuration parameter.
 <!-- pyml disable-num-lines 9 md013-->
 
 | Option       | Required                                        | Description                                                                                                                       |
-| ------------ | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+|--------------|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | `<ttl>`      | No                                              | Time to live in milliseconds                                                                                                      |
 | `<ttb>`      | No                                              | Time to birth in milliseconds                                                                                                     |
 | `<ttr>`      | No                                              | Time to refresh in milliseconds                                                                                                   |
@@ -622,7 +622,7 @@ configuration parameter.
 
 **Synopsis:**
 
-The `lookup` verb should be used to lookup the value shared by another atSign
+The `lookup` verb should be used to look up the value shared by another atSign
 user.
 
 **Syntax:**
@@ -672,8 +672,8 @@ data:
  }
 ```
 
-If the operation is to lookup the metadata and the data together then the result
-should be wrapped in a JSON in the following format:
+If the operation is to look up the metadata and the data together then the 
+result should be wrapped in a JSON in the following format:
 
 `data:<Value and Metadata in a JSON>`
 
@@ -713,7 +713,7 @@ following error and close the connection:
 
 `error:AT0003-Invalid Syntax`
 
-For whatever reasons, If the handshake with another atServer fails, then the
+If the handshake with another atServer fails, then the
 atServer should return the following error:
 
 `data:AT0008-Handshake failure`
@@ -723,7 +723,7 @@ value saved by the user as is.
 
 `data:<value>`
 
-If the operation is to lookup the metadata only then the result should be
+If the operation is to look up the metadata only then the result should be
 wrapped in a JSON in the following format:
 
 `data:<Metadata in a JSON>`
@@ -741,7 +741,7 @@ otherwise the public key has to be returned.
 <!-- pyml disable-num-lines 6 md013-->
 
 | Option        | Required | Description                                                                                             |
-| ------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+|---------------|----------|---------------------------------------------------------------------------------------------------------|
 | `<operation>` | No       | `meta` - returns the metadata of the AtKey, `all` - returns both the data and the metadata of the AtKey |
 | `<atKey>`     | Yes      | the key to be looked up                                                                                 |
 | `<@sign>`     | Yes      | the atSign owner of the key                                                                             |
@@ -750,7 +750,7 @@ otherwise the public key has to be returned.
 
 **Synopsis:**
 
-The `plookup` verb enables to lookup the value of the public key shared by
+The `plookup` verb enables to look up the value of the public key shared by
 another atSign user.
 
 **Syntax:**
@@ -808,7 +808,7 @@ another atSign user.
 <!-- pyml disable-num-lines 6 md013-->
 
 | Option        | Required | Description                                                                                             |
-| ------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+|---------------|----------|---------------------------------------------------------------------------------------------------------|
 | `<operation>` | No       | `meta` - returns the metadata of the AtKey, `all` - returns both the data and the metadata of the AtKey |
 | `<atKey>`     | Yes      | the key to be looked up                                                                                 |
 | `<@sign>`     | Yes      | the atSign owner of the key                                                                             |
@@ -872,7 +872,7 @@ llookup should return the value as is.
 <!-- pyml disable-num-lines 6 md013-->
 
 | Option        | Required | Description                                                                                             |
-| ------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+|---------------|----------|---------------------------------------------------------------------------------------------------------|
 | `<operation>` | No       | `meta` - returns the metadata of the AtKey, `all` - returns both the data and the metadata of the AtKey |
 | `<atKey>`     | Yes      | the key to be looked up                                                                                 |
 | `<@sign>`     | Yes      | the atSign owner of the key                                                                             |
@@ -917,7 +917,7 @@ exist will still respond with a commit id.
 <!-- pyml disable-num-lines 8 md013-->
 
 | Option       | Required | Description                                                               |
-| ------------ | -------- | ------------------------------------------------------------------------- |
+|--------------|----------|---------------------------------------------------------------------------|
 | `:cached:`   | No       | Include `:cached:` if the key you are deleting is cached in your atServer |
 | `:public:`   | No       | Include `:public:` if the key you are deleting is a public key            |
 | `<for@sign>` | No       | The key's sharedWith atSign                                               |
@@ -939,7 +939,7 @@ Following is the regex:
 
 **Response:**
 
-The `sync` verb returns a json array of the commit entries from the given commit
+The `sync` verb returns a JSON array of the commit entries from the given commit
 id to the current commit id. Further, The `sync` verb accepts -1 as argument
 which returns all the commit entries.
 
@@ -1059,14 +1059,14 @@ If successful, returns
 
 **Description:**
 
-Deletes a notification from the notificaiton log. Note that this is different
+Deletes a notification from the notification log. Note that this is different
 from `notify:delete`, which sends a notification relating to the deletion of a
 key.
 
 **Options:**
 
 | Option             | Required | Description                |
-| ------------------ | -------- | -------------------------- |
+|--------------------|----------|----------------------------|
 | `<notificationId>` | Yes      | The id of the notification |
 
 #### The `notify:status` verb
@@ -1193,7 +1193,7 @@ passing filter criteria as regex to `monitor` verb.
 <!-- pyml disable-num-lines 4 md013-->
 
 | Option    | Required | Description                                                      |
-| --------- | -------- | ---------------------------------------------------------------- |
+|-----------|----------|------------------------------------------------------------------|
 | `<regex>` | No       | The regex to filter the notificaitons during the monitor session |
 
 ### APKAM Verbs
@@ -1299,7 +1299,7 @@ reject the enrollment request.
 | Option                         | Required | Description                                                       |
 |--------------------------------|----------|-------------------------------------------------------------------|
 <!-- pyml disable-num-lines 3 md013-->
-| `<operation>`                  | Yes      | Name of the enroll operation e.g approve, request,deny etc.,      |
+| `<operation>`                  | Yes      | Name of the enroll operation e.g. approve, request,deny etc., |
 <!-- pyml disable-num-lines 3 md013-->
 | `<deviceName>`                 | No       | Unique identifier of the device requesting enrollment             |
 <!-- pyml disable-num-lines 3 md013-->
@@ -1348,7 +1348,7 @@ Response
 data: 123abc // otp expires in 10 seconds
 ```
 
-Save a semi permanent passcode to secondary server
+Save a semi-permanent passcode to secondary server
 
 `otp:put:123abc`
 
@@ -1360,7 +1360,7 @@ data:ok
 
 **Description:**
 
-Otp verb can be used to get an one time passcode from server to be used for
+Otp verb can be used to get a one time passcode from server to be used for
 APKAM enrollment. It can also be used to save a one time
 semi-permanent passcode which can be used a client/command line
 app for enrollments.
@@ -1551,7 +1551,7 @@ error:AT0022-Exception: noop:<durationInMillis> where the duration maximum is 50
 <!-- pyml disable-num-lines 21 md013-->
 
 | **Error Code** | **Error Message**                                     | **Description**                                                                                                                                         |
-| -------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
 | AT0001         | Server exception                                      | Exception occurs when there is an issue while starting the server.                                                                                      |
 | AT0002         | DataStore exception                                   | Exception occurs during keystore operations (GET/PUT/DELETE).                                                                                           |
 | AT0003         | Invalid syntax                                        | Exception occurs if we give any invalid command to the server.                                                                                          |
@@ -1573,7 +1573,7 @@ error:AT0022-Exception: noop:<durationInMillis> where the duration maximum is 50
 
 ## Glossary
 
-> atProtocol (Pronounced, at protocol) &nbsp; atSign (Pronounced, at sign)
+> Atsign Protocol (Pronounced, at protocol) &nbsp; atSign (Pronounced, at sign)
 > atSign is a unique name that a user gets when enrolled with atsign.com &nbsp;
 > atDirectory &nbsp; atServer &nbsp; Verb &nbsp; Public Key &nbsp; Private Key
 > &nbsp; Shared Secret &nbsp; Default Keys &nbsp; Key &nbsp; Value &nbsp;

--- a/specification/building_on_the_atsign_protocol.md
+++ b/specification/building_on_the_atsign_protocol.md
@@ -1,0 +1,264 @@
+# Building on the Atsign Protocol
+
+A pointer document for **app developers** building on the Atsign
+Protocol via the Dart `at_client_sdk`. If you are implementing an
+atServer or atClient in another language, you want
+[`atsign_protocol_specification.md`](./atsign_protocol_specification.md)
+instead.
+
+## Pick the right SDK package
+
+| If you're building…                            | Start with                                                                                                            |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| A Flutter app (mobile / desktop / IoT)         | [`at_client_flutter`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter) — ships pre-built onboarding and APKAM widgets. |
+| A Dart CLI or server app                       | [`at_cli_commons`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_cli_commons) for boilerplate, plus [`at_onboarding_cli`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli) for first-time provisioning. |
+| Custom onboarding tooling                      | [`at_auth`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth) — platform-neutral lifecycle core.                                  |
+| Shared types (`AtKey`, `Metadata`, exceptions) | [`at_commons`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons)                                                          |
+
+Web is **not** a supported target — Flutter web does not have
+implementations of the platform plugins onboarding and local storage
+depend on.
+
+## The atSign lifecycle
+
+There are three phases between "I don't own an atSign" and "my app is
+talking to the atServer". The
+[`at_auth` README](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth#the-atsign-lifecycle)
+has the full writeup; the short version:
+
+1. **Register** an atSign — free at
+   [my.noports.com/no-ports-plans](https://my.noports.com/no-ports-plans),
+   paid / custom at [my.atsign.com](https://my.atsign.com). You receive a
+   **CRAM secret** by email.
+2. **Onboard** the atSign exactly once: CRAM-authenticate, generate
+   the master keypairs, store private halves in `.atKeys` (CLI) or the
+   device keychain (Flutter). **Master keys are root of trust — back
+   them up.**
+3. **Authenticate** subsequent apps via **APKAM enrollment** —
+   request a namespace-scoped keypair (`{'todos': 'rw'}`), the
+   master-keys holder approves, the atServer issues new revocable
+   credentials.
+
+CLI tools that ship with `at_onboarding_cli`:
+
+```sh
+dart pub global activate at_onboarding_cli
+at_register -e your_email@example.com   # Phase 1+2 in one shot
+at_activate -a @alice                   # Phase 2 with email OTP
+at_activate -a @alice -c <cram_secret>  # Phase 2 with explicit CRAM
+```
+
+For the APKAM flow, see
+[`at_onboarding_cli/example/apkam_examples/`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli/example/apkam_examples).
+
+## Day-to-day API: prefer `AtCollection<T>`
+
+For app code, the recommended surface is
+**[`AtCollection<T>`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client#collections)**
+— a typed, shareable, locally-indexed collection of records with a
+query builder and event streams. AtCollection hides the AtKey,
+metadata, notification-regex, and sync ceremony that the
+low-level `AtClient.put/get/delete` API exposes.
+
+The low-level API still exists — see
+[The escape hatch](#the-escape-hatch-low-level-atclient-putgetdelete)
+below — but for everything that resembles "CRUD on typed records",
+`AtCollection<T>` is the right tool.
+
+### Sketch
+
+```dart
+final todos = await atClient.collection<Todo>(
+  'todos.my_app',                       // fully-qualified namespace
+  const Duration(days: 7),              // default expiration
+  fromJson: Todo.fromJson,              // (de)serialiser
+  typeTag: 'Todo',                      // required: discriminator for polymorphic types
+  eventsFromLocalSecondary: true,       // required: event-driven (true) or notification-driven (false)
+);
+
+// Create + share
+final item = await todos.create(
+  obj: Todo('write readme'),
+  sharedWith: {'@bob'.toAtsign()},
+);
+
+// Update
+item.obj.done = true;
+await todos.update(item);
+
+// Diff-shared-with — preferred over update() when only changing recipients
+await todos.updateSharedWith(item, sharedWith: {'@bob'.toAtsign(), '@carol'.toAtsign()});
+
+// Delete (cascade-deletes sub-collections if any)
+await todos.delete(item, cascade: true);
+
+// Existence probe (cheap; uses plookup, not scan)
+final exists = await todos.exists(item.id, item.owner);
+```
+
+### Queries
+
+Build immutable, composable queries that fetch one-shot or watch
+live:
+
+```dart
+final overdue = todos.query()
+    .where((t) => !t.obj.done)
+    .wherePath($TodoFields.due.lt(DateTime.now()))   // typed AST predicate
+    .orderBy((t) => t.obj.due)
+    .thenBy((t) => t.id)
+    .limit(20);
+
+final list  = await overdue.get();              // one-shot List<CItem<Todo>>
+final live  = overdue.watch();                  // Stream<List<CItem<Todo>>>
+final count = await todos.query().where((t) => !t.obj.done).count();
+final byOwner = await todos.query().groupBy<Atsign>((t) => t.owner);
+```
+
+For the common parent + children pattern (e.g. blog posts +
+comments, invoices + line items):
+
+```dart
+final tree = posts.query().watchWithSub<Comment>(
+  subName: 'comments',
+  subFromJson: Comment.fromJson,
+  subTypeTag: 'Comment',
+);
+// Stream<List<WithChildren<Post, Comment>>>
+```
+
+For arbitrary-depth hierarchies, use `watchWithTree`.
+
+### Read receipts
+
+Built into `CItem<T>`; idempotent on both sides.
+
+```dart
+// Reader side
+await incomingItem.markReadByMe();
+
+// Owner side
+final readers = await myItem.readBy;            // Future<Set<Atsign>>
+todos.readReceipts.listen((e) => print('${e.from} read ${e.id}'));
+```
+
+### Lifecycle event streams
+
+```dart
+// Items entering visibility (when their availableAt passes)
+todos.availableEvents.listen((e) => ...);
+
+// Items about to expire
+todos.expiringSoonEvents(leadTime: Duration(hours: 1))
+     .listen((e) => ...);
+
+// All updates / deletes
+todos.events.listen((e) => switch (e) {
+  CItemUpdated()  => ...,
+  CItemDeleted()  => ...,
+  CSubItemUpdated() => ...,
+  // ...
+});
+```
+
+### Sub-collections
+
+Children scoped to a parent `CItem`, with opt-in cascade-delete:
+
+```dart
+final comments = posts.subCollection<Comment>(
+  parent: post,
+  subName: 'comments',
+  defaultExpiration: const Duration(days: 30),
+  fromJson: Comment.fromJson,
+  typeTag: 'Comment',
+);
+await comments.create(obj: Comment('nice one'), sharedWith: {/* … */});
+
+await posts.delete(post, cascade: true);   // removes its comments too
+```
+
+### Worked examples
+
+Code worth opening rather than reading about:
+
+- **Dart / CLI** —
+  [`at_client/example/bin/`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client/example/bin):
+  - `collections_primitives.dart` — basic CRUD + sharing
+  - `collections_domain_objects.dart` — typed domain objects + fromJson
+  - `collections_generic.dart` — polymorphic types (single role)
+  - `collections_binary.dart` — `Uint8List` storage
+  - `collections_subcollections.dart` — parent + children with cascade
+  - `collections_invoices.dart` — concurrent typed-predicate watches +
+    `PathField` range bucketing + 10k-item create/delete cycle
+  - `collections_todos.dart` — full interactive TUI (shared todos)
+- **Flutter** —
+  [`at_client_flutter/examples/todos`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter/examples/todos)
+  is the canonical reference Flutter app. Same feature set as
+  `collections_todos.dart`, rendered through the mobile / desktop
+  widget stack the way a shipping app would use it.
+
+## The escape hatch — low-level `AtClient.put/get/delete`
+
+For the rare cases AtCollection doesn't fit — bespoke key shapes,
+non-record-shaped values, integration with legacy data — the raw
+SDK surface is still available:
+
+```dart
+await atClient.put(atKey, value);
+final value = await atClient.get(atKey);
+await atClient.delete(atKey);
+```
+
+You should almost never need this if you are using AtCollection.
+
+## How the protocol relates to the SDK
+
+The SDK's public API does not map 1:1 to wire verbs. The
+AtCollection API in particular synthesises multiple verbs per call.
+
+| App-level call                                     | Underlying verb(s)                                                         |
+| -------------------------------------------------- | -------------------------------------------------------------------------- |
+| `collection.create(obj: …, sharedWith: …)`         | `update` (self copy) + `update` per recipient + `notify` per recipient    |
+| `collection.update(item)`                          | `update` (self copy) + `update` per recipient + `notify` per recipient    |
+| `collection.updateSharedWith(item, …)`             | `update` per added/removed recipient + `notify` (no self-key rewrite)     |
+| `collection.delete(item, cascade: …)`              | `delete` (self) + `delete` per recipient + `notify:delete` per recipient + cascade walk |
+| `collection.exists(id, owner)`                     | `plookup` (own atSign) or local cache lookup (other atSigns)              |
+| `collection.query().get()`                         | local store read; one-time `sync:from` if stale                            |
+| `collection.query().watch()`                       | local store subscription; `monitor` underneath for cross-atSign updates    |
+| `collection.events` / `availableEvents` / `expiringSoonEvents` | local-store `DataEvent` stream + client-side scheduled timers     |
+| `markReadByMe()` / `readBy`                        | `update` / `llookup` against the reserved `__rr` sub-collection            |
+| `atClient.put(atKey, value)`                       | `update`                                                                   |
+| `atClient.get(atKey)` (own atSign)                 | `llookup`                                                                  |
+| `atClient.get(atKey)` (other atSign)               | `lookup`                                                                   |
+| `atClient.delete(atKey)`                           | `delete`                                                                   |
+| `atClient.getAtKeys(regex: …)`                     | `scan`                                                                     |
+| `notificationService.notify(...)`                  | `notify`                                                                   |
+| `notificationService.subscribe(...)`               | `monitor`                                                                  |
+| `syncService.sync()` / `waitUntilCaughtUp()`       | `sync:from` (paginated)                                                    |
+| `AtOnboardingService.onboard()`                    | `from` + `cram` + `update` (×N)                                            |
+| `AtOnboardingService.authenticate()`               | `from` + `pkam`                                                            |
+| `AtEnrollment.submit(...)`                         | `from` + `enroll:request`                                                  |
+| `AtEnrollment.approve(...)`                        | `enroll:approve`                                                           |
+
+If you find yourself reaching for something neither AtCollection nor
+the high-level AtClient API exposes, drop down to
+[`at_lookup`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_lookup),
+which is the verb-level transport, and consult the full
+[Atsign Protocol Specification](./atsign_protocol_specification.md).
+
+## What's changing soon
+
+Several active workstreams will materially change parts of the
+protocol surface — post-quantum encryption, fast sync ("fsync"), a
+new on-disk AtKeys structure, a canonical conformance test suite,
+and others. See
+[Appendix C of the specification](./atsign_protocol_specification.md#appendix-c--significant-near-term-projects)
+for the current snapshot.
+
+## Further reading
+
+- [Atsign Protocol Specification](./atsign_protocol_specification.md) — wire-level reference
+- [atPlatform docs](https://docs.atsign.com/) — high-level concepts
+- [pub.dev: at_client](https://pub.dev/packages/at_client) — the main SDK package
+- [`at_client` README — Collections section](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client#collections) — authoritative on the AtCollection API

--- a/specification/building_on_the_atsign_protocol.md
+++ b/specification/building_on_the_atsign_protocol.md
@@ -8,12 +8,12 @@ instead.
 
 ## Pick the right SDK package
 
-| If you're building…                            | Start with                                                                                                            |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| A Flutter app (mobile / desktop / IoT)         | [`at_client_flutter`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter) — ships pre-built onboarding and APKAM widgets. |
+| If you're building…                            | Start with                                                                                                                                                                                                                                                                   |
+|------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| A Flutter app (mobile / desktop / IoT)         | [`at_client_flutter`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter) — ships pre-built onboarding and APKAM widgets.                                                                                                              |
 | A Dart CLI or server app                       | [`at_cli_commons`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_cli_commons) for boilerplate, plus [`at_onboarding_cli`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli) for first-time provisioning. |
-| Custom onboarding tooling                      | [`at_auth`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth) — platform-neutral lifecycle core.                                  |
-| Shared types (`AtKey`, `Metadata`, exceptions) | [`at_commons`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons)                                                          |
+| Custom onboarding tooling                      | [`at_auth`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth) — platform-neutral lifecycle core.                                                                                                                                               |
+| Shared types (`AtKey`, `Metadata`, exceptions) | [`at_commons`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons)                                                                                                                                                                            |
 
 Web is **not** a supported target — Flutter web does not have
 implementations of the platform plugins onboarding and local storage
@@ -23,7 +23,8 @@ depend on.
 
 There are three phases between "I don't own an atSign" and "my app is
 talking to the atServer". The
-[`at_auth` README](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth#the-atsign-lifecycle)
+[
+`at_auth` README](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth#the-atsign-lifecycle)
 has the full writeup; the short version:
 
 1. **Register** an atSign — free at
@@ -49,12 +50,15 @@ at_activate -a @alice -c <cram_secret>  # Phase 2 with explicit CRAM
 ```
 
 For the APKAM flow, see
-[`at_onboarding_cli/example/apkam_examples/`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli/example/apkam_examples).
+[
+`at_onboarding_cli/example/apkam_examples/`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli/example/apkam_examples).
 
 ## Day-to-day API: prefer `AtCollection<T>`
 
 For app code, the recommended surface is
-**[`AtCollection<T>`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client#collections)**
+**[
+`AtCollection<T>`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client#collections)
+**
 — a typed, shareable, locally-indexed collection of records with a
 query builder and event streams. AtCollection hides the AtKey,
 metadata, notification-regex, and sync ceremony that the
@@ -68,18 +72,22 @@ below — but for everything that resembles "CRUD on typed records",
 ### Sketch
 
 ```dart
-final todos = await atClient.collection<Todo>(
-  'todos.my_app',                       // fully-qualified namespace
-  const Duration(days: 7),              // default expiration
-  fromJson: Todo.fromJson,              // (de)serialiser
-  typeTag: 'Todo',                      // required: discriminator for polymorphic types
-  eventsFromLocalSecondary: true,       // required: event-driven (true) or notification-driven (false)
+
+final todos = await
+atClient.collection<Todo>
+('todos.my_app
+'
+, // fully-qualified namespace
+const Duration(days: 7), // default expiration
+fromJson: Todo.fromJson, // (de)serialiser
+typeTag: 'Todo', // required: discriminator for polymorphic types
+eventsFromLocalSecondary: true, // required: event-driven (true) or notification-driven (false)
 );
 
 // Create + share
 final item = await todos.create(
-  obj: Todo('write readme'),
-  sharedWith: {'@bob'.toAtsign()},
+obj: Todo('write readme'),
+sharedWith: {'@bob'.toAtsign()},
 );
 
 // Update
@@ -102,23 +110,38 @@ Build immutable, composable queries that fetch one-shot or watch
 live:
 
 ```dart
+
 final overdue = todos.query()
     .where((t) => !t.obj.done)
-    .wherePath($TodoFields.due.lt(DateTime.now()))   // typed AST predicate
+    .wherePath($TodoFields.due.lt(DateTime.now())) // typed AST predicate
     .orderBy((t) => t.obj.due)
     .thenBy((t) => t.id)
     .limit(20);
 
-final list  = await overdue.get();              // one-shot List<CItem<Todo>>
-final live  = overdue.watch();                  // Stream<List<CItem<Todo>>>
-final count = await todos.query().where((t) => !t.obj.done).count();
-final byOwner = await todos.query().groupBy<Atsign>((t) => t.owner);
+final list = await
+overdue.get
+(); // one-shot List<CItem<Todo>>
+final live = overdue.watch(); // Stream<List<CItem<Todo>>>
+final count = await
+todos.query
+().where
+(
+(t) => !t.obj.done).count();
+final byOwner = await todos.query().groupBy<Atsign>((
+t
+)
+=>
+t
+.
+owner
+);
 ```
 
 For the common parent + children pattern (e.g. blog posts +
 comments, invoices + line items):
 
 ```dart
+
 final tree = posts.query().watchWithSub<Comment>(
   subName: 'comments',
   subFromJson: Comment.fromJson,
@@ -135,29 +158,36 @@ Built into `CItem<T>`; idempotent on both sides.
 
 ```dart
 // Reader side
-await incomingItem.markReadByMe();
+await
+incomingItem.markReadByMe
+();
 
 // Owner side
-final readers = await myItem.readBy;            // Future<Set<Atsign>>
-todos.readReceipts.listen((e) => print('${e.from} read ${e.id}'));
+final readers = await
+myItem.readBy; // Future<Set<Atsign>>
+todos.readReceipts.listen
+(
+(e) => print('${e.from} read ${e.id}'));
 ```
 
 ### Lifecycle event streams
 
 ```dart
 // Items entering visibility (when their availableAt passes)
-todos.availableEvents.listen((e) => ...);
+todos.availableEvents.listen
+(
+(e) => ...);
 
 // Items about to expire
 todos.expiringSoonEvents(leadTime: Duration(hours: 1))
-     .listen((e) => ...);
+    .listen((e) => ...);
 
 // All updates / deletes
 todos.events.listen((e) => switch (e) {
-  CItemUpdated()  => ...,
-  CItemDeleted()  => ...,
-  CSubItemUpdated() => ...,
-  // ...
+CItemUpdated() => ...,
+CItemDeleted() => ...,
+CSubItemUpdated() => ...,
+// ...
 });
 ```
 
@@ -166,6 +196,7 @@ todos.events.listen((e) => switch (e) {
 Children scoped to a parent `CItem`, with opt-in cascade-delete:
 
 ```dart
+
 final comments = posts.subCollection<Comment>(
   parent: post,
   subName: 'comments',
@@ -173,9 +204,14 @@ final comments = posts.subCollection<Comment>(
   fromJson: Comment.fromJson,
   typeTag: 'Comment',
 );
-await comments.create(obj: Comment('nice one'), sharedWith: {/* … */});
+await
+comments.create
+(
+obj: Comment('nice one'), sharedWith: {/* … */});
 
-await posts.delete(post, cascade: true);   // removes its comments too
+await posts.delete(post, cascade:
+true
+); // removes its comments too
 ```
 
 ### Worked examples
@@ -183,17 +219,19 @@ await posts.delete(post, cascade: true);   // removes its comments too
 Code worth opening rather than reading about:
 
 - **Dart / CLI** —
-  [`at_client/example/bin/`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client/example/bin):
-  - `collections_primitives.dart` — basic CRUD + sharing
-  - `collections_domain_objects.dart` — typed domain objects + fromJson
-  - `collections_generic.dart` — polymorphic types (single role)
-  - `collections_binary.dart` — `Uint8List` storage
-  - `collections_subcollections.dart` — parent + children with cascade
-  - `collections_invoices.dart` — concurrent typed-predicate watches +
-    `PathField` range bucketing + 10k-item create/delete cycle
-  - `collections_todos.dart` — full interactive TUI (shared todos)
+  [
+  `at_client/example/bin/`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client/example/bin):
+    - `collections_primitives.dart` — basic CRUD + sharing
+    - `collections_domain_objects.dart` — typed domain objects + fromJson
+    - `collections_generic.dart` — polymorphic types (single role)
+    - `collections_binary.dart` — `Uint8List` storage
+    - `collections_subcollections.dart` — parent + children with cascade
+    - `collections_invoices.dart` — concurrent typed-predicate watches +
+      `PathField` range bucketing + 10k-item create/delete cycle
+    - `collections_todos.dart` — full interactive TUI (shared todos)
 - **Flutter** —
-  [`at_client_flutter/examples/todos`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter/examples/todos)
+  [
+  `at_client_flutter/examples/todos`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter/examples/todos)
   is the canonical reference Flutter app. Same feature set as
   `collections_todos.dart`, rendered through the mobile / desktop
   widget stack the way a shipping app would use it.
@@ -205,8 +243,14 @@ non-record-shaped values, integration with legacy data — the raw
 SDK surface is still available:
 
 ```dart
-await atClient.put(atKey, value);
-final value = await atClient.get(atKey);
+await
+atClient.put
+(atKey, value);
+
+final value = await
+atClient.get
+(
+atKey);
 await atClient.delete(atKey);
 ```
 
@@ -217,33 +261,34 @@ You should almost never need this if you are using AtCollection.
 The SDK's public API does not map 1:1 to wire verbs. The
 AtCollection API in particular synthesises multiple verbs per call.
 
-| App-level call                                     | Underlying verb(s)                                                         |
-| -------------------------------------------------- | -------------------------------------------------------------------------- |
-| `collection.create(obj: …, sharedWith: …)`         | `update` (self copy) + `update` per recipient + `notify` per recipient    |
-| `collection.update(item)`                          | `update` (self copy) + `update` per recipient + `notify` per recipient    |
-| `collection.updateSharedWith(item, …)`             | `update` per added/removed recipient + `notify` (no self-key rewrite)     |
-| `collection.delete(item, cascade: …)`              | `delete` (self) + `delete` per recipient + `notify:delete` per recipient + cascade walk |
-| `collection.exists(id, owner)`                     | `plookup` (own atSign) or local cache lookup (other atSigns)              |
-| `collection.query().get()`                         | local store read; one-time `sync:from` if stale                            |
-| `collection.query().watch()`                       | local store subscription; `monitor` underneath for cross-atSign updates    |
-| `collection.events` / `availableEvents` / `expiringSoonEvents` | local-store `DataEvent` stream + client-side scheduled timers     |
-| `markReadByMe()` / `readBy`                        | `update` / `llookup` against the reserved `__rr` sub-collection            |
-| `atClient.put(atKey, value)`                       | `update`                                                                   |
-| `atClient.get(atKey)` (own atSign)                 | `llookup`                                                                  |
-| `atClient.get(atKey)` (other atSign)               | `lookup`                                                                   |
-| `atClient.delete(atKey)`                           | `delete`                                                                   |
-| `atClient.getAtKeys(regex: …)`                     | `scan`                                                                     |
-| `notificationService.notify(...)`                  | `notify`                                                                   |
-| `notificationService.subscribe(...)`               | `monitor`                                                                  |
-| `syncService.sync()` / `waitUntilCaughtUp()`       | `sync:from` (paginated)                                                    |
-| `AtOnboardingService.onboard()`                    | `from` + `cram` + `update` (×N)                                            |
-| `AtOnboardingService.authenticate()`               | `from` + `pkam`                                                            |
-| `AtEnrollment.submit(...)`                         | `from` + `enroll:request`                                                  |
-| `AtEnrollment.approve(...)`                        | `enroll:approve`                                                           |
+| App-level call                                                 | Underlying verb(s)                                                                      |
+|----------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| `collection.create(obj: …, sharedWith: …)`                     | `update` (self copy) + `update` per recipient + `notify` per recipient                  |
+| `collection.update(item)`                                      | `update` (self copy) + `update` per recipient + `notify` per recipient                  |
+| `collection.updateSharedWith(item, …)`                         | `update` per added/removed recipient + `notify` (no self-key rewrite)                   |
+| `collection.delete(item, cascade: …)`                          | `delete` (self) + `delete` per recipient + `notify:delete` per recipient + cascade walk |
+| `collection.exists(id, owner)`                                 | `plookup` (own atSign) or local cache lookup (other atSigns)                            |
+| `collection.query().get()`                                     | local store read; one-time `sync:from` if stale                                         |
+| `collection.query().watch()`                                   | local store subscription; `monitor` underneath for cross-atSign updates                 |
+| `collection.events` / `availableEvents` / `expiringSoonEvents` | local-store `DataEvent` stream + client-side scheduled timers                           |
+| `markReadByMe()` / `readBy`                                    | `update` / `llookup` against the reserved `__rr` sub-collection                         |
+| `atClient.put(atKey, value)`                                   | `update`                                                                                |
+| `atClient.get(atKey)` (own atSign)                             | `llookup`                                                                               |
+| `atClient.get(atKey)` (other atSign)                           | `lookup`                                                                                |
+| `atClient.delete(atKey)`                                       | `delete`                                                                                |
+| `atClient.getAtKeys(regex: …)`                                 | `scan`                                                                                  |
+| `notificationService.notify(...)`                              | `notify`                                                                                |
+| `notificationService.subscribe(...)`                           | `monitor`                                                                               |
+| `syncService.sync()` / `waitUntilCaughtUp()`                   | `sync:from` (paginated)                                                                 |
+| `AtOnboardingService.onboard()`                                | `from` + `cram` + `update` (×N)                                                         |
+| `AtOnboardingService.authenticate()`                           | `from` + `pkam`                                                                         |
+| `AtEnrollment.submit(...)`                                     | `from` + `enroll:request`                                                               |
+| `AtEnrollment.approve(...)`                                    | `enroll:approve`                                                                        |
 
 If you find yourself reaching for something neither AtCollection nor
 the high-level AtClient API exposes, drop down to
-[`at_lookup`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_lookup),
+[
+`at_lookup`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_lookup),
 which is the verb-level transport, and consult the full
 [Atsign Protocol Specification](./atsign_protocol_specification.md).
 
@@ -258,7 +303,11 @@ for the current snapshot.
 
 ## Further reading
 
-- [Atsign Protocol Specification](./atsign_protocol_specification.md) — wire-level reference
+- [Atsign Protocol Specification](./atsign_protocol_specification.md) —
+  wire-level reference
 - [atPlatform docs](https://docs.atsign.com/) — high-level concepts
-- [pub.dev: at_client](https://pub.dev/packages/at_client) — the main SDK package
-- [`at_client` README — Collections section](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client#collections) — authoritative on the AtCollection API
+- [pub.dev: at_client](https://pub.dev/packages/at_client) — the main SDK
+  package
+- [
+  `at_client` README — Collections section](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client#collections) —
+  authoritative on the AtCollection API

--- a/specification/building_on_the_atsign_protocol.md
+++ b/specification/building_on_the_atsign_protocol.md
@@ -1,4 +1,4 @@
-# Building on the Atsign Protocol
+# Atsign Protocol app developer guide
 
 A pointer document for **app developers** building on the Atsign
 Protocol via the Dart `at_client_sdk`. If you are implementing an
@@ -6,39 +6,38 @@ atServer or atClient in another language, you want
 [`atsign_protocol_specification.md`](./atsign_protocol_specification.md)
 instead.
 
+<!-- pyml disable-num-lines 999 md013-->
+
 ## Pick the right SDK package
 
 | If you're building…                            | Start with                                                                                                                                                                                                                                                                   |
 |------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| A Flutter app (mobile / desktop / IoT)         | [`at_client_flutter`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter) — ships pre-built onboarding and APKAM widgets.                                                                                                              |
+| A Flutter app (mobile / desktop / IoT)         | [`at_client_flutter`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter): ships pre-built onboarding and APKAM widgets.                                                                                                               |
 | A Dart CLI or server app                       | [`at_cli_commons`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_cli_commons) for boilerplate, plus [`at_onboarding_cli`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli) for first-time provisioning. |
-| Custom onboarding tooling                      | [`at_auth`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth) — platform-neutral lifecycle core.                                                                                                                                               |
+| Custom onboarding tooling                      | [`at_auth`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth): platform-neutral lifecycle core.                                                                                                                                                |
 | Shared types (`AtKey`, `Metadata`, exceptions) | [`at_commons`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons)                                                                                                                                                                            |
 
-Web is **not** a supported target — Flutter web does not have
-implementations of the platform plugins onboarding and local storage
-depend on.
+Web is **not** a supported target. Flutter web has no implementations
+of the platform plugins onboarding and local storage depend on.
 
 ## The atSign lifecycle
 
-There are three phases between "I don't own an atSign" and "my app is
+There are 3 phases between "I don't own an atSign" and "my app is
 talking to the atServer". The
-[
-`at_auth` README](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth#the-atsign-lifecycle)
+[`at_auth` README](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth#the-atsign-lifecycle)
 has the full writeup; the short version:
 
-1. **Register** an atSign — free at
+1. **Register** an atSign, free at
    [my.noports.com/no-ports-plans](https://my.noports.com/no-ports-plans),
-   paid / custom at [my.atsign.com](https://my.atsign.com). You receive a
-   **CRAM secret** by email.
+   paid / custom at [my.atsign.com](https://my.atsign.com). You receive
+   a **CRAM secret** by email.
 2. **Onboard** the atSign exactly once: CRAM-authenticate, generate
    the master keypairs, store private halves in `.atKeys` (CLI) or the
-   device keychain (Flutter). **Master keys are root of trust — back
+   device keychain (Flutter). **Master keys are root of trust. Back
    them up.**
-3. **Authenticate** subsequent apps via **APKAM enrollment** —
-   request a namespace-scoped keypair (`{'todos': 'rw'}`), the
-   master-keys holder approves, the atServer issues new revocable
-   credentials.
+3. **Authenticate** subsequent apps via **APKAM enrollment**: request
+   a namespace-scoped keypair (`{'todos': 'rw'}`), the master-keys
+   holder approves, and the atServer issues new revocable credentials.
 
 CLI tools that ship with `at_onboarding_cli`:
 
@@ -50,44 +49,37 @@ at_activate -a @alice -c <cram_secret>  # Phase 2 with explicit CRAM
 ```
 
 For the APKAM flow, see
-[
-`at_onboarding_cli/example/apkam_examples/`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli/example/apkam_examples).
+[`at_onboarding_cli/example/apkam_examples/`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli/example/apkam_examples).
 
 ## Day-to-day API: prefer `AtCollection<T>`
 
 For app code, the recommended surface is
-**[
-`AtCollection<T>`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client#collections)
-**
-— a typed, shareable, locally-indexed collection of records with a
+[`AtCollection<T>`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client#collections),
+a typed, shareable, locally-indexed collection of records with a
 query builder and event streams. AtCollection hides the AtKey,
-metadata, notification-regex, and sync ceremony that the
-low-level `AtClient.put/get/delete` API exposes.
+metadata, notification-regex, and sync ceremony that the low-level
+`AtClient.put/get/delete` API exposes.
 
-The low-level API still exists — see
-[The escape hatch](#the-escape-hatch-low-level-atclient-putgetdelete)
-below — but for everything that resembles "CRUD on typed records",
+The low-level API still exists, see
+[The escape hatch](#the-escape-hatch-low-level-atclientputgetdelete)
+below, but for everything that resembles "CRUD on typed records",
 `AtCollection<T>` is the right tool.
 
 ### Sketch
 
 ```dart
-
-final todos = await
-atClient.collection<Todo>
-('todos.my_app
-'
-, // fully-qualified namespace
-const Duration(days: 7), // default expiration
-fromJson: Todo.fromJson, // (de)serialiser
-typeTag: 'Todo', // required: discriminator for polymorphic types
-eventsFromLocalSecondary: true, // required: event-driven (true) or notification-driven (false)
+final todos = await atClient.collection<Todo>(
+  'todos.my_app',                // fully-qualified namespace
+  const Duration(days: 7),       // default expiration
+  fromJson: Todo.fromJson,       // (de)serialiser
+  typeTag: 'Todo',               // required: discriminator for polymorphic types
+  eventsFromLocalSecondary: true,// required: event-driven (true) vs notification-driven (false)
 );
 
 // Create + share
 final item = await todos.create(
-obj: Todo('write readme'),
-sharedWith: {'@bob'.toAtsign()},
+  obj: Todo('write readme'),
+  sharedWith: {'@bob'.toAtsign()},
 );
 
 // Update
@@ -95,7 +87,10 @@ item.obj.done = true;
 await todos.update(item);
 
 // Diff-shared-with — preferred over update() when only changing recipients
-await todos.updateSharedWith(item, sharedWith: {'@bob'.toAtsign(), '@carol'.toAtsign()});
+await todos.updateSharedWith(
+  item,
+  sharedWith: {'@bob'.toAtsign(), '@carol'.toAtsign()},
+);
 
 // Delete (cascade-deletes sub-collections if any)
 await todos.delete(item, cascade: true);
@@ -106,42 +101,26 @@ final exists = await todos.exists(item.id, item.owner);
 
 ### Queries
 
-Build immutable, composable queries that fetch one-shot or watch
-live:
+Build immutable, composable queries that fetch one-shot or watch live:
 
 ```dart
-
 final overdue = todos.query()
     .where((t) => !t.obj.done)
-    .wherePath($TodoFields.due.lt(DateTime.now())) // typed AST predicate
+    .wherePath($TodoFields.due.lt(DateTime.now()))   // typed AST predicate
     .orderBy((t) => t.obj.due)
     .thenBy((t) => t.id)
     .limit(20);
 
-final list = await
-overdue.get
-(); // one-shot List<CItem<Todo>>
-final live = overdue.watch(); // Stream<List<CItem<Todo>>>
-final count = await
-todos.query
-().where
-(
-(t) => !t.obj.done).count();
-final byOwner = await todos.query().groupBy<Atsign>((
-t
-)
-=>
-t
-.
-owner
-);
+final list  = await overdue.get();              // one-shot List<CItem<Todo>>
+final live  = overdue.watch();                  // Stream<List<CItem<Todo>>>
+final count = await todos.query().where((t) => !t.obj.done).count();
+final byOwner = await todos.query().groupBy<Atsign>((t) => t.owner);
 ```
 
-For the common parent + children pattern (e.g. blog posts +
-comments, invoices + line items):
+For the common parent + children pattern (e.g. blog posts + comments,
+invoices + line items):
 
 ```dart
-
 final tree = posts.query().watchWithSub<Comment>(
   subName: 'comments',
   subFromJson: Comment.fromJson,
@@ -158,36 +137,29 @@ Built into `CItem<T>`; idempotent on both sides.
 
 ```dart
 // Reader side
-await
-incomingItem.markReadByMe
-();
+await incomingItem.markReadByMe();
 
 // Owner side
-final readers = await
-myItem.readBy; // Future<Set<Atsign>>
-todos.readReceipts.listen
-(
-(e) => print('${e.from} read ${e.id}'));
+final readers = await myItem.readBy;            // Future<Set<Atsign>>
+todos.readReceipts.listen((e) => print('${e.from} read ${e.id}'));
 ```
 
 ### Lifecycle event streams
 
 ```dart
 // Items entering visibility (when their availableAt passes)
-todos.availableEvents.listen
-(
-(e) => ...);
+todos.availableEvents.listen((e) => doSomething(e));
 
 // Items about to expire
 todos.expiringSoonEvents(leadTime: Duration(hours: 1))
-    .listen((e) => ...);
+     .listen((e) => doSomething(e));
 
 // All updates / deletes
 todos.events.listen((e) => switch (e) {
-CItemUpdated() => ...,
-CItemDeleted() => ...,
-CSubItemUpdated() => ...,
-// ...
+  CItemUpdated()    => onUpdated(e),
+  CItemDeleted()    => onDeleted(e),
+  CSubItemUpdated() => onSubUpdated(e),
+  // ...
 });
 ```
 
@@ -196,7 +168,6 @@ CSubItemUpdated() => ...,
 Children scoped to a parent `CItem`, with opt-in cascade-delete:
 
 ```dart
-
 final comments = posts.subCollection<Comment>(
   parent: post,
   subName: 'comments',
@@ -204,53 +175,44 @@ final comments = posts.subCollection<Comment>(
   fromJson: Comment.fromJson,
   typeTag: 'Comment',
 );
-await
-comments.create
-(
-obj: Comment('nice one'), sharedWith: {/* … */});
+await comments.create(
+  obj: Comment('nice one'),
+  sharedWith: {/* … */},
+);
 
-await posts.delete(post, cascade:
-true
-); // removes its comments too
+await posts.delete(post, cascade: true);   // removes its comments too
 ```
 
 ### Worked examples
 
-Code worth opening rather than reading about:
+Code worth opening rather than reading about. The Dart and CLI
+examples live under
+[`at_client/example/bin/`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client/example/bin):
 
-- **Dart / CLI** —
-  [
-  `at_client/example/bin/`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client/example/bin):
-    - `collections_primitives.dart` — basic CRUD + sharing
-    - `collections_domain_objects.dart` — typed domain objects + fromJson
-    - `collections_generic.dart` — polymorphic types (single role)
-    - `collections_binary.dart` — `Uint8List` storage
-    - `collections_subcollections.dart` — parent + children with cascade
-    - `collections_invoices.dart` — concurrent typed-predicate watches +
-      `PathField` range bucketing + 10k-item create/delete cycle
-    - `collections_todos.dart` — full interactive TUI (shared todos)
-- **Flutter** —
-  [
-  `at_client_flutter/examples/todos`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter/examples/todos)
-  is the canonical reference Flutter app. Same feature set as
-  `collections_todos.dart`, rendered through the mobile / desktop
-  widget stack the way a shipping app would use it.
+- `collections_primitives.dart`: basic CRUD and sharing
+- `collections_domain_objects.dart`: typed domain objects and `fromJson`
+- `collections_generic.dart`: polymorphic types (single role)
+- `collections_binary.dart`: `Uint8List` storage
+- `collections_subcollections.dart`: parent and children with cascade
+- `collections_invoices.dart`: concurrent typed-predicate watches with
+  `PathField` range bucketing and a 10k-item create/delete cycle
+- `collections_todos.dart`: full interactive TUI (shared todos)
 
-## The escape hatch — low-level `AtClient.put/get/delete`
+The canonical Flutter reference app is
+[`at_client_flutter/examples/todos`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter/examples/todos).
+It has the same feature set as `collections_todos.dart`, rendered
+through the mobile and desktop widget stack the way a shipping app
+would use it.
 
-For the rare cases AtCollection doesn't fit — bespoke key shapes,
-non-record-shaped values, integration with legacy data — the raw
-SDK surface is still available:
+## The escape hatch, low-level `AtClient.put/get/delete`
+
+For the rare cases AtCollection doesn't fit, bespoke key shapes,
+non-record-shaped values, integration with legacy data, the raw SDK
+surface is still available:
 
 ```dart
-await
-atClient.put
-(atKey, value);
-
-final value = await
-atClient.get
-(
-atKey);
+await atClient.put(atKey, value);
+final value = await atClient.get(atKey);
 await atClient.delete(atKey);
 ```
 
@@ -258,8 +220,8 @@ You should almost never need this if you are using AtCollection.
 
 ## How the protocol relates to the SDK
 
-The SDK's public API does not map 1:1 to wire verbs. The
-AtCollection API in particular synthesises multiple verbs per call.
+The SDK's public API does not map 1:1 to wire verbs. The AtCollection
+API in particular synthesises multiple verbs per call.
 
 | App-level call                                                 | Underlying verb(s)                                                                      |
 |----------------------------------------------------------------|-----------------------------------------------------------------------------------------|
@@ -287,27 +249,25 @@ AtCollection API in particular synthesises multiple verbs per call.
 
 If you find yourself reaching for something neither AtCollection nor
 the high-level AtClient API exposes, drop down to
-[
-`at_lookup`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_lookup),
+[`at_lookup`](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_lookup),
 which is the verb-level transport, and consult the full
 [Atsign Protocol Specification](./atsign_protocol_specification.md).
 
-## What's changing soon
+## Upcoming changes
 
 Several active workstreams will materially change parts of the
-protocol surface — post-quantum encryption, fast sync ("fsync"), a
-new on-disk AtKeys structure, a canonical conformance test suite,
-and others. See
-[Appendix C of the specification](./atsign_protocol_specification.md#appendix-c--significant-near-term-projects)
+protocol surface, post-quantum encryption, fast sync ("fsync"), a new
+on-disk AtKeys structure, a canonical conformance test suite, and
+others. See
+[Appendix C of the specification](./atsign_protocol_specification.md#appendix-c-significant-near-term-projects)
 for the current snapshot.
 
 ## Further reading
 
-- [Atsign Protocol Specification](./atsign_protocol_specification.md) —
+- [Atsign Protocol Specification](./atsign_protocol_specification.md):
   wire-level reference
-- [atPlatform docs](https://docs.atsign.com/) — high-level concepts
-- [pub.dev: at_client](https://pub.dev/packages/at_client) — the main SDK
-  package
-- [
-  `at_client` README — Collections section](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client#collections) —
-  authoritative on the AtCollection API
+- [atPlatform docs](https://docs.atsign.com/), high-level concepts
+- [pub.dev: at_client](https://pub.dev/packages/at_client), the main
+  SDK package
+- [`at_client` README, Collections section](https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client#collections)
+ , authoritative on the AtCollection API

--- a/usage-examples/how-notifications-work.md
+++ b/usage-examples/how-notifications-work.md
@@ -1,4 +1,4 @@
-# How atProtocol notifications work
+# How Atsign Protocol notifications work
 
 ## High level
 

--- a/usage-examples/how-to-exchange-encrypted-data.md
+++ b/usage-examples/how-to-exchange-encrypted-data.md
@@ -9,6 +9,7 @@ payloads are encrypted in the same way as is described below for the `put`
 and `get` operations.
 
 <!-- TOC -->
+
 * [How to exchange encrypted data](#how-to-exchange-encrypted-data)
 * [Background](#background)
 * [Goals](#goals)
@@ -57,7 +58,8 @@ another atSign.
 
 ## Technical prerequisites
 
-Ability to
+Ability to:
+
 * create RSA encryption public/private keypairs and use them to do encryption
 and decryption
 * cryptographically sign data using a private key, and verify signatures using
@@ -212,6 +214,7 @@ shared symmetric key. Java example:
 ### Key descriptions
 
 .atKeys:
+
 * `aesPkamPublicKey`: used by the AtServer to verify the signature (unused by
 Client)
 * `aesPkamPrivateKey`: key for signing the challenge during authentication
@@ -222,6 +225,7 @@ to AtSign
 AES symmetric key
 
 Other:
+
 * `aesSymmetricalKey`: Generated for each atSign that is communicated with.
 This is created the first time one AtSign tries to communicate with another.
 

--- a/usage-examples/how-to-exchange-encrypted-data.md
+++ b/usage-examples/how-to-exchange-encrypted-data.md
@@ -37,7 +37,7 @@ and `get` operations.
 ## Background
 
 Some details of how the atPlatform works are not specified in detail by the
-atProtocol itself, but are usage conventions which are embedded in the client
+Atsign Protocol itself, but are usage conventions which are embedded in the client
 SDKs. As a result, building new client software, be it in a new language or
 building alternative client software for a language for which client software
 is already available, currently requires the engineer to base their efforts


### PR DESCRIPTION
## Summary

- **Replace v1 of the Atsign Protocol Specification** with a 2200+-line, implementer-grade reference covering every byte that crosses the wire between an atClient, atServer, or atDirectory. The previous v1 is preserved at `specification/atsign_protocol_specification.old.md` so existing references still resolve.
- **Add a short companion `building_on_the_atsign_protocol.md`** for app developers building on the protocol via the Dart `at_client_sdk`. AtCollection-first per the current SDK emphasis; the raw `AtClient.put/get/delete` surface is demoted to an escape hatch.
- **Peripheral cleanups** in the same change: nav (`SUMMARY.md`, `README.md`, `.gitbook.yaml`) retargeted at the new files; "atProtocol" → "Atsign Protocol" in `info/license.md` and the `usage-examples/` files for branding consistency; JetBrains `.gitignore` template added.

## What's new in the spec vs v1

- **APKAM-first authentication chapter.** CRAM is positioned as one-time bootstrap; PKAM is documented as the underlying signature mechanism.
- **Inter-atServer protocol pull-out chapter.** The previous spec didn't cover this. Includes the full `from`→proof→`pol`→signed-pubkey-lookup→success handshake step-by-step, plus `lookup` proxying and `notify` cross-delivery. The chapter explicitly enumerates the verbs that ever cross the inter-atServer channel (`from`, `pol`, `lookup`, `plookup`, `scan`, `notify`) and states the negative: atServers do not sync with one another, do not replicate, and have no peer relationship.
- **End-to-end encryption chapter framed as an atClient concern.** atServers store opaque ciphertext and opaque metadata; no plaintext ever reaches them. Server-side value-level filtering is therefore architecturally impossible (a security property, not a perf gap).
- **Five worked flows** end-to-end: CRAM bootstrap, APKAM enrollment with the full encryption-envelope chain, cross-atSign lookup via pol, monitor + notify round-trip, sync resumption.
- **Appendix A** terse verb reference table for ctrl-F lookup.
- **Appendix B** legacy and deprecated items (CRAM-as-permanent-auth, `sync` without `:from:`, `messageType:text`, `pubKeyCS`, `stream`, the `keys` verb).
- **Appendix C: Significant near-term projects** (linked from §1) workstreams that will materially change parts of this spec: post-quantum cryptography (#1889/#1891/#1893), fast-sync / fsync (#1894), new AtKeys structure (#1892), exception-handling standardisation (#1910), canonical SDK conformance test suite (#1900), Java APKAM (operations #348), others. So implementers don't commit to surfaces that are about to change.
- **Appendix D: Inconsistencies and quirks** (linked from §1) wire surprises that the per-verb sections don't make obvious: error-code separator drift, per-verb response-framing differences, `notify:list` semantics flipping on auth mode, `from` self-vs-cross response shapes, expired-key lookups returning `data:null`, and so on.

## Companion app-dev pointer card

`building_on_the_atsign_protocol.md` leads with `AtCollection<T>`: typed records, query builder (`where`/`wherePath`/`orderBy`/`thenBy`/`limit`/`distinct`/`count`/`groupBy`/`get`/`watch`/`watchWithSub`/`watchWithTree`), read receipts, lifecycle event streams (`availableEvents`/`expiringSoonEvents`), sub-collections. Includes a mapping table showing how each AtCollection call decomposes to wire verbs.

## Markdown lint and writing-style passes

The follow-up commits in this PR bring all touched markdown into compliance with the repo's `pymarkdownlnt` CI config and apply the writing-style rules from `~/.claude/WRITING_STYLE.md`. Em-dashes removed from prose (kept in code blocks and reference-data tables); gerund headings rephrased; bold-term-explanation lists rewritten as prose or compact tables (the glossary stays as-is, since term-definition format is intrinsic to a glossary); numerals for numbers ≥ 3; filler softeners cut. The full repo passes `pymarkdownlnt -s 'plugins.md024.siblings_only=$!True' scan */*.md` cleanly.

## Test plan

- [ ] Render in GitBook and confirm both new docs link correctly into the existing tree.
- [ ] Spot-check the verb reference (Appendix A) anchors against the per-section headings.
- [ ] Cross-check the `pol` handshake description in §15.2 against `at_secondary_server/lib/src/verb/handler/pol_verb_handler.dart`.
- [ ] Cross-check the cram digest input in §9.2 against `at_lookup/lib/src/at_lookup_impl.dart` (the input is the full unprefixed `from` response, not the trailing UUID alone).
- [ ] Verify the Appendix C issue links resolve.
- [ ] Confirm the Pymarkdownlnt CI workflow passes on this branch.